### PR TITLE
Added aggregator pom and plugin version update tool

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -33,6 +33,27 @@ Demonstrates how to convert AsciiDoc to PDF using Asciidoctor PDF with the Ascii
 link:asciidoc-site-example/README.adoc[asciidoc-site-example]::
 Demonstrates how to process AsciiDoc in a Maven site using the Asciidoctor Maven plugin.
 
+== Updating Asciidoctor Maven plugin version
+
+In case it is required to test a specific version of the plugin (e.g. local SNAPSHOT version), a tool has been included to update the version in all examples.
+To change the plugin’s version follow the next steps:
+
+. Set the desired version in the _<asciidoctor.maven.plugin.version>_ property in the _pom.xml_ file located at the root (asciidoctor-maven-examples folder). For instance:
+
+[source,xml,indent=2]
+----
+<asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
+----
+
+[start=2]
+. Execute the _validate_ maven goal with the _update-properties_ profile:
+
+[source,indent=2]
+----
+$ mvn validate -Pupdate-properties
+----
+
+
 == Copyright and Licensing
 
 Copyright (C) 2014 The Asciidoctor Project.

--- a/asciidoc-site-example/pom.xml
+++ b/asciidoc-site-example/pom.xml
@@ -7,13 +7,13 @@
     <version>1.0.0-SNAPSHOT</version>
     <name>AsciiDoc Maven Site Example</name>
     <description>An example project that demonstrates how to process AsciiDoc in a Maven site using the Asciidoctor Maven plugin.</description>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.0</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
         <jruby.version>1.7.17</jruby.version>
     </properties>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -7,13 +7,13 @@
     <version>1.0.0-SNAPSHOT</version>
     <name>AsciiDoc to HTML Maven Example</name>
     <description>An example project that demonstrates how to convert AsciiDoc to HTML5 using the Asciidoctor Maven plugin.</description>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.0</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
         <jruby.version>1.7.17</jruby.version>
     </properties>
-    
+
     <build>
         <defaultGoal>process-resources</defaultGoal>
         <plugins>

--- a/asciidoc-to-pdf-example/pom.xml
+++ b/asciidoc-to-pdf-example/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.0</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
         <jruby.version>1.7.17</jruby.version>
     </properties>
 
@@ -88,7 +88,7 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>generate-html-doc</id>
+                        <id>generate-pdf-doc</id>
                         <phase>generate-resources</phase>
                         <goals>
                             <goal>process-asciidoc</goal>

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.0</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
         <jruby.version>1.7.17</jruby.version>
     </properties>
 

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.0</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
         <jruby.version>1.7.17</jruby.version>
     </properties>
 

--- a/docbook-pipeline-jdocbook-example/pom.xml
+++ b/docbook-pipeline-jdocbook-example/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.0</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
         <jruby.version>1.7.17</jruby.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,26 +2,62 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <groupId>org.asciidoctor.maven</groupId>
     <artifactId>asciidoc-asciidoctor-maven-examples</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
-    
+
     <name>AsciiDoc Maven Examples</name>
-    <description>A set of example projects that show different use cases of AsciiDoc integration with maven.</description>
-    
+    <description>Collection of sample projects that demonstrate numerous ways to use the Asciidoctor Maven plugin in a Maven project.</description>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
+        <jruby.version>1.7.17</jruby.version>
     </properties>
-    
+
     <modules>
-      <module>asciidoc-site-example</module>
-      <module>asciidoc-to-html-example</module>
-      <module>asciidoc-to-pdf-example</module>
-      <module>asciidoctor-diagram-example</module>
-      <module>docbook-pipeline-docbkx-example</module>
-      <module>docbook-pipeline-jdocbook-example</module>
+        <module>asciidoc-site-example</module>
+        <module>asciidoc-to-html-example</module>
+        <module>asciidoc-to-pdf-example</module>
+        <module>asciidoctor-diagram-example</module>
+        <module>docbook-pipeline-docbkx-example</module>
+        <module>docbook-pipeline-jdocbook-example</module>
     </modules>
-   
+
+    <profiles>
+        <profile>
+            <id>update-properties</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.gmaven</groupId>
+                        <artifactId>gmaven-plugin</artifactId>
+                        <version>1.5</version>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <source>${pom.basedir}/update-properties.groovy</source>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.codehaus.groovy</groupId>
+                                <artifactId>groovy-nio</artifactId>
+                                <version>2.3.7</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/update-properties.groovy
+++ b/update-properties.groovy
@@ -1,0 +1,47 @@
+/**
+ * Updates all properties ending with 'version' copying its value from the 
+ * parent project.
+ * This script is made as an alternative to `versions-maven-plugin`, which 
+ * validates versions and does not allow to use local installed snapshots :(
+ */
+import groovy.io.FileType;
+
+def root = new File('.')
+
+/* parent properties parsing */
+def parentPom = new XmlSlurper().parse(new File(root,'pom.xml'))
+def replacements = [:]
+parentPom.properties.children().each {
+    if (it.name().endsWith('version')) {
+        replacements["${it.name()}>"] = it.text()
+    }
+}
+
+if (replacements.size() > 0) {
+    println "[INFO] Found ${replacements.size()} properties to update:"
+    replacements.each { k, v ->
+        println "[INFO]\t\t${k[0..-2]} = $v"
+    }
+}
+
+/* child pom's update */
+root.eachDir { folder ->
+    folder.listFiles({it.name == 'pom.xml'} as FileFilter).each { File pom ->
+        // println "[INFO] Parsing ${pom.absolutePath}"
+        File copy = new File(pom.absolutePath+'-TEMP')
+        copy.withWriter('UTF-8')  { writer ->
+            pom.eachLine ('UTF-8') { line ->
+                replacements.each { k, v ->
+                    if (line.contains(k)) {
+                        // println "[INFO] Updating property ${k[0..-2]}" 
+                        line = "${line.split(k)[0]}$k$v</$k"
+                    }
+                }
+                /* manually concatenate line break to avoid windows evil bytes */
+                writer.write("$line\n")
+            }
+        }
+        pom.delete()
+        copy.renameTo(pom)
+    }
+}


### PR DESCRIPTION
This PR includes the points discused in #2 and the updated asciidoctor-maven-plugin to fix #1.
The aggregator includes the examples as sub-modules with no dependencies from them, this preserves the independence of each example, but still allows to build all of them together.

About the tool to update the versions, the `versions:update-properties` option does to work since it validates the versions against maven central. This makes impossible to test locally installed versions.
Instead, gmaven-plugin have been used to execute a groovy script that updates the poms copying certain properties from the aggregator (I missed gradle here).

BTW: I've seen that images are not included in the pdf's examples, but since a new integration with pdf is on the way I'll just check it with the other tool.
