### PR TITLE
updated 'asciidoc-to-pdf-example' to use asciidoctorj-pdf and diagram's readme revision

### DIFF
--- a/asciidoc-to-pdf-example/pom.xml
+++ b/asciidoc-to-pdf-example/pom.xml
@@ -14,55 +14,9 @@
         <jruby.version>1.7.17</jruby.version>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>rubygems-proxy-releases</id>
-            <name>RubyGems.org Proxy (Releases)</name>
-            <url>http://rubygems-proxy.torquebox.org/releases</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <dependencies>
-        <dependency>
-            <groupId>rubygems</groupId>
-            <artifactId>asciidoctor-pdf</artifactId>
-            <version>1.5.0.alpha.4</version>
-            <type>gem</type>
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>rubygems</groupId>
-                    <artifactId>asciidoctor</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-    </dependencies>
     <build>
         <defaultGoal>process-resources</defaultGoal>
         <plugins>
-            <plugin>
-                <groupId>de.saumya.mojo</groupId>
-                <artifactId>gem-maven-plugin</artifactId>
-                <version>1.0.5</version>
-                <configuration>
-                    <!-- align JRuby version with AsciidoctorJ to avoid redundant downloading -->
-                    <jrubyVersion>1.7.9</jrubyVersion>
-                    <gemHome>${project.build.directory}/gems</gemHome>
-                    <gemPath>${project.build.directory}/gems</gemPath>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>initialize</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
@@ -77,10 +31,15 @@
                     </dependency>
                 </dependencies>
                 -->
+                <dependencies>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj-pdf</artifactId>
+                        <version>1.5.0-alpha.6</version>
+                    </dependency>
+                </dependencies>
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>
-                    <!-- The gem-maven-plugin appends the scope (e.g., provided) to the gemPath defined in the plugin configuration -->
-                    <gemPath>${project.build.directory}/gems-provided</gemPath>
                     <!-- Attributes common to all output formats -->
                     <attributes>
                         <sourcedir>${project.build.sourceDirectory}</sourcedir>
@@ -94,14 +53,10 @@
                             <goal>process-asciidoc</goal>
                         </goals>
                         <configuration>
-                            <requires>
-                                <require>asciidoctor-pdf</require>
-                            </requires>
                             <backend>pdf</backend>
                             <!-- WARNING callout bullets don't yet work with CodeRay -->
                             <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
-                                <imagesdir>./images</imagesdir>
                                 <pagenums/>
                                 <toc/>
                                 <idprefix/>

--- a/asciidoctor-diagram-example/README.adoc
+++ b/asciidoctor-diagram-example/README.adoc
@@ -9,3 +9,12 @@ Convert the AsciiDoc to HTML5 by invoking the `process-resources` goal (configur
  $ mvn
 
 Open the file _target/generated-docs/example-manual.html_ in your browser to see the generated HTML file containing the generated diagram images.
+
+[NOTE]
+====
+Asciidoctor Diagram bundles both the ditaa and PlantUML libraries and will use them to generate diagrams. In order to generate diagrams using Graphviz, you must install it separately (meaning the _dot_ command must be available on your PATH).
+
+Visit link:http://www.graphviz.org/[Graphviz' site] for details on how to install the _dot_ command tool.
+====
+
+For more examples and information about Asciidoctor Diagrams see link:http://asciidoctor.org/news/2014/02/18/plain-text-diagrams-in-asciidoctor/[]


### PR DESCRIPTION
This PR includes:

. *Updated 'asciidoc-to-pdf-example' to use asciidoctorj-pdf*: just updated the pom to use the current version of _asciidoctorj-pdf_ instead of using the old method of including the gem _asciidoctor-pdf_. The purpouse of this change is to update all examples to the latest version and usage of asciidoctorj-*.

. *Added a note about usage of `dot` command to asciidoctor-diagram-example's README*: to execute the diagram example the Graphviz command tools must be installed. This is clearly stated in the following article: http://asciidoctor.org/news/2014/02/18/plain-text-diagrams-in-asciidoctor/, but not in the example. I think it's nice to offer the information and the reference to the article here too.