### PR TITLE
Show how to specify Graphviz's dot command location in pom.xml ...

### DIFF
--- a/asciidoctor-diagram-example/README.adoc
+++ b/asciidoctor-diagram-example/README.adoc
@@ -10,11 +10,31 @@ Convert the AsciiDoc to HTML5 by invoking the `process-resources` goal (configur
 
 Open the file _target/generated-docs/example-manual.html_ in your browser to see the generated HTML file containing the generated diagram images.
 
-[NOTE]
-====
-Asciidoctor Diagram bundles both the ditaa and PlantUML libraries and will use them to generate diagrams. In order to generate diagrams using Graphviz, you must install it separately (meaning the _dot_ command must be available on your PATH).
+== Graphviz configuration
+Asciidoctor Diagram bundles both the ditaa and PlantUML libraries and will use them to generate diagrams.
+In order to generate diagrams using Graphviz, you must install it separately.
+There are two options to reference the installed Graphviz's _dot_ tool in order to generate diagrams: system's PATH or plug-in attributes configuration.
 
-Visit link:http://www.graphviz.org/[Graphviz' site] for details on how to install the _dot_ command tool.
-====
+=== Configuration via system's PATH
+Visit link:http://www.graphviz.org/[Graphviz' site] for details on how to install the _dot_ command tool, and to make the _dot_ command available on your system's PATH.
 
+=== Configuration via plug-in attributes
+Once Graphviz binaries from the link:http://www.graphviz.org/[Graphviz' site] are available on the system, the plug-in attributes in the pom.xml can be used to reference to the _dot_ tool directly.
+This type of configuration may be especially useful when working in a CI environment.
+Example:
+
+[source,xml]
+----
+<plugin>
+    <groupId>org.asciidoctor</groupId>
+    <artifactId>asciidoctor-maven-plugin</artifactId>
+    ...
+    <configuration>
+		<attributes>
+			<graphvizdot>/PATH/TO/Graphviz/bin/dot</graphvizdot>
+		</attributes>
+		...
+----
+
+== References
 For more examples and information about Asciidoctor Diagrams see link:http://asciidoctor.org/news/2014/02/18/plain-text-diagrams-in-asciidoctor/[]

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -84,6 +84,15 @@
                     <requires>
                         <require>asciidoctor-diagram</require>
                     </requires>
+                    <attributes>
+						<!-- Example below shows how to specify in this pom instead of System's PATH, the location of dot command of Graphviz, required by PlantUML libraries -->
+						<!-- Windows:
+							<graphvizdot>C:\Program Files (x86)\Graphviz2.38\bin\dot.exe</graphvizdot>
+						-->
+						<!-- *nix :
+							<graphvizdot>/usr/local/bin/dot</graphvizdot>
+						-->
+					</attributes>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
... instead of System's PATH.
With reference to 6d4a0dc , I believe this is very helpful to show, for
two main reasons:
- some users may want to just set in the pom instead of System PATH
- could be referenced with properties, if the build happens via CI