### PR TITLE
Add "extension-example" (an asciidoctorj extension written in java)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -34,6 +34,10 @@ link:asciidoc-multiple-inputs-example/README.adoc[asciidoc-multiple-inputs-examp
 An example project that demonstrates how to convert multiple input AsciiDoc documents to HTML5 and PDF using the
 Asciidoctor Maven plugin.
 
+link:java-extension-example/README.adoc[java-extension-example]::
+An example project that demonstrates how to create an extension for Asciidoctorj (written in Java) and how to use it in an other documentation Maven module.
+
+
 == Updating Asciidoctor Maven plugin version
 
 In case it is required to test a specific version of the plugin (e.g. local SNAPSHOT version), a tool has been included to update the version in all examples.

--- a/java-extension-example/README.adoc
+++ b/java-extension-example/README.adoc
@@ -1,0 +1,29 @@
+= Asciidoctor Maven Plugin: Java Extension Example
+
+An example project that demonstrates how to create an extension for Asciidoctorj (written in Java) and how to use it in an other documentation Maven module.
+
+== Description
+
+=== asciidoctorj-twitter-extension
+
+A maven plugin containing a the code that adds a `twitter` macro to asciidoctor.
+
+With this extension you can write:
+
+----
+Contact: twitter:mojavelinux[] (project lead lead of the asciidoctor project)
+----
+
+=== asciidoctor-with-extension-example
+
+An example project (very similar to `asciidoc-to-html-example`) that demonstrates how to use the `asciidoctorj-twitter-extension`.
+
+It convert some AsciiDoc code using the `twitter` macro to HTML5.
+
+== Usage
+
+Convert the AsciiDoc to HTML5 by invoking the `compile` goal (configured as the default goal) on this aggregator module (`java-extension-example`):
+
+ $ mvn
+
+Open the file _asciidoctor-with-extension-example/target/generated-docs/example-manual.html_ in your browser to see the generated HTML file.

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.asciidoctor.maven</groupId>
+    <artifactId>asciidoctor-with-extension-example</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>AsciiDoc to HTML with extension Maven Example</name>
+    <description>An example project that demonstrates how to convert AsciiDoc to HTML5 using the Asciidoctor Maven plugin with the twitter extension.</description>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
+        <jruby.version>1.7.17</jruby.version>
+    </properties>
+
+    <build>
+        <defaultGoal>process-resources</defaultGoal>
+        <plugins>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>${asciidoctor.maven.plugin.version}</version>
+                <dependencies>
+                    <!-- Add the twitter extension for AsciidoctorJ -->
+                    <dependency>
+                        <groupId>org.asciidoctor.maven</groupId>
+                        <artifactId>asciidoctorj-twitter-extension</artifactId>
+                        <version>1.0.0-SNAPSHOT</version>
+                    </dependency>
+                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                    <!--
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj</artifactId>
+                        <version>1.5.2-SNAPSHOT</version>
+                    </dependency>
+                    -->
+                </dependencies>
+                <configuration>
+                    <sourceDirectory>src/docs/asciidoc</sourceDirectory>
+                    <!-- If you set baseDir to ${project.basedir}, top-level includes are resolved relative to the project root -->
+                    <!--
+                    <baseDir>${project.basedir}</baseDir>
+                    -->
+                    <!-- Attributes common to all output formats -->
+                    <attributes>
+                        <endpoint-url>http://example.org</endpoint-url>
+                        <sourcedir>${project.build.sourceDirectory}</sourcedir>
+                        <project-version>${project.version}</project-version>
+                    </attributes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>asciidoctor-with-extension-example</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html5</backend>
+                            <sourceHighlighter>coderay</sourceHighlighter>
+                            <!--
+                            Scenarios for linking vs embedding assets:
+
+                            Link to both stylesheets and images::
+
+                              - don't set embedAssets option
+                              - set linkcss attribute to true
+                              - set imagesdir attribute to path relative to AsciiDoc source file
+
+                              <attributes>
+                                  <linkcss>true</linkcss>
+                                  <imagesdir>./images</imagesdir>
+                              </attributes>
+
+                            Embed stylesheets and images::
+                            
+                              - set embedAssets option to true
+                              - don't set linkcss attribute
+                              - set imagesdir attribute to path relative to project root
+
+                              <embedAssets>true</embedAssets>
+                              <attributes>
+                                  <imagesdir>src/docs/asciidoc/images</imagesdir>
+                              </attributes>
+
+                            Link to stylesheets but embed images::
+                            
+                              - set embedAssets option to true
+                              - set linkcss attribute to true
+                              - set imagesdir attribute to path relative to project root
+
+                              <embedAssets>true</embedAssets>
+                              <attributes>
+                                  <linkcss>true</linkcss>
+                                  <imagesdir>src/docs/asciidoc/images</imagesdir>
+                              </attributes>
+
+                            Embed stylesheets but link images (default)::
+                            
+                              - don't set embedAssets option
+                              - don't set linkcss attribute
+                              - set imagesdir attribute to path relative to AsciiDoc source file
+
+                              <attributes>
+                                  <imagesdir>./images</imagesdir>
+                              </attributes>
+
+                            IMPORTANT: When you enable image embedding, you must qualify the path the the imagesdir, as shown above.
+                            -->
+                            <attributes>
+                                <icons>font</icons>
+                                <sectanchors>true</sectanchors>
+                                <!-- set the idprefix to blank -->
+                                <idprefix/>
+                                <idseparator>-</idseparator>
+                                <docinfo1>true</docinfo1>
+                            </attributes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--
+            NOTE: Use the maven-resources-plugin if there are assets outside the AsciiDoc source folder
+                  that need to be copied to the generated-docs. The Maven plugin automatically copies
+                  non-AsciiDoc files in the AsciiDoc source folder to generated-docs.
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <id>copy-asciidoc-resources</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>src/docs/resources</directory>
+                                    <includes>
+                                        <include>**/*.jpg</include>
+                                        <include>**/*.png</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                            <outputDirectory>target/generated-docs</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            -->
+        </plugins>
+    </build>
+</project>

--- a/java-extension-example/asciidoctor-with-extension-example/src/docs/asciidoc/example-manual.adoc
+++ b/java-extension-example/asciidoctor-with-extension-example/src/docs/asciidoc/example-manual.adoc
@@ -1,0 +1,8 @@
+= Example Manual
+Doc Writer <doc.writer@example.org>
+2015-06-12
+:revnumber: {project-version}
+
+Writing an AsciiDoctor extension using Java is _easy_! Ask twitter:mrhaki[] about it.
+
+This is a user manual for an empty project.

--- a/java-extension-example/asciidoctorj-twitter-extension/pom.xml
+++ b/java-extension-example/asciidoctorj-twitter-extension/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.asciidoctor.maven</groupId>
+    <artifactId>asciidoctorj-twitter-extension</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>Asciidoctorj twitter extension</name>
+    <description>An extension for asciidoctorj providing a twitter macro available as Maven plugin.</description>
+    <dependencies>
+        <dependency>
+            <groupId>org.asciidoctor</groupId>
+            <artifactId>asciidoctorj</artifactId>
+            <version>1.5.2</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <defaultGoal>compile</defaultGoal>
+    </build>
+</project>

--- a/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacro.java
+++ b/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacro.java
@@ -1,0 +1,43 @@
+package org.asciidoctorj.twitter.extension;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.asciidoctor.ast.AbstractBlock;
+import org.asciidoctor.ast.Inline;
+import org.asciidoctor.extension.InlineMacroProcessor;
+
+public class TwitterMacro extends InlineMacroProcessor {
+
+	public TwitterMacro(String macroName, Map<String, Object> config) {
+		super(macroName, config);
+	}
+
+	@Override
+	protected Object process(AbstractBlock parent, String twitterHandle,
+			Map<String, Object> attributes) {
+
+		String twitterLink;
+		String twitterLinkText;
+		if (twitterHandle == null || twitterHandle.isEmpty()) {
+			twitterLink = "http://www.twitter.com/";
+			twitterLinkText = "Twitter";
+		} else {
+			twitterLink = "http://www.twitter.com/" + twitterHandle;
+			// Prepend twitterHandle with @ as text link:
+			twitterLinkText = "@" + twitterHandle;
+		}
+
+		// Define options for an 'anchor' element:
+		Map<String, Object> options = new HashMap<String, Object>();
+		options.put("type", ":link");
+		options.put("target", twitterLink);
+
+		// Create the 'anchor' node:
+		Inline inlineTwitterLink = createInline(parent, "anchor",
+				twitterLinkText, attributes, options);
+
+		// Convert to String value:
+		return inlineTwitterLink.convert();
+	}
+}

--- a/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacroExtension.java
+++ b/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacroExtension.java
@@ -1,0 +1,15 @@
+package org.asciidoctorj.twitter.extension;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.extension.JavaExtensionRegistry;
+import org.asciidoctor.extension.spi.ExtensionRegistry;
+
+public class TwitterMacroExtension implements ExtensionRegistry {
+
+	public void register(Asciidoctor asciidoctor) {
+		JavaExtensionRegistry javaExtensionRegistry = asciidoctor
+				.javaExtensionRegistry();
+
+		javaExtensionRegistry.inlineMacro("twitter", TwitterMacro.class);
+	}
+}

--- a/java-extension-example/asciidoctorj-twitter-extension/src/main/resources/META-INF/services/org.asciidoctor.extension.spi.ExtensionRegistry
+++ b/java-extension-example/asciidoctorj-twitter-extension/src/main/resources/META-INF/services/org.asciidoctor.extension.spi.ExtensionRegistry
@@ -1,0 +1,2 @@
+# File: src/main/resources/META-INF/services/org.asciidoctor.extension.spi.ExtensionRegistry
+org.asciidoctorj.twitter.extension.TwitterMacroExtension

--- a/java-extension-example/pom.xml
+++ b/java-extension-example/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.asciidoctor.maven</groupId>
+    <artifactId>java-extension-example</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <name>Extension example aggreator</name>
+    <description>The aggregator project for an asciidoc project using an asciidoctorj extension with maven.</description>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>asciidoctorj-twitter-extension</module>
+        <module>asciidoctor-with-extension-example</module>
+    </modules>
+
+    <build>
+        <defaultGoal>compile</defaultGoal>
+    </build>
+</project>


### PR DESCRIPTION
This is based on the article published by @mrhaki:
[Awesome Asciidoctor: Write Extensions Using Groovy (or Java)](
http://mrhaki.blogspot.ch/2014/08/awesome-asciidoc-write-extensions-using.html)
I rewrote the groovy example in java and put it in a normal maven project.

Related discussion: [example of an asciidoctorj extension using java and maven](
http://discuss.asciidoctor.org/example-of-an-asciidoctorj-extension-using-java-and-maven-td3370.html).

Disclamer: I am not a maven expert (and still in the process of learning asciidoctor). Please review my setup.