### PR TITLE
Version update and showing how to set the JRuby version

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -46,7 +46,7 @@ Asciidoctor Maven plugin relies on https://github.com/asciidoctor/asciidoctor[as
         <artifactId>asciidoctor-maven-plugin</artifactId>
         <version>${asciidoctor.maven.plugin.version}</version>
         <dependencies>
-        	<dependency>
+            <dependency>
                 <groupId>org.jruby</groupId>
                 <artifactId>jruby-complete</artifactId>
                 <version>${jruby.version}</version>

--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ Refer to the README file in each individual project to learn how to run it.
 
 == Example catalog
 
-link:asciidoc-to-html-example/README.adoc[asciidoc-to-html-example] (aka “The Quickstart”)::
+link:asciidoc-to-html-example/README.adoc[asciidoc-to-html-example] (aka "`The Quickstart`")::
 Demonstrates how to convert AsciiDoc to HTML5 using the Asciidoctor Maven plugin.
 
 link:docbook-pipeline-docbkx-example/README.adoc[docbook-pipeline-docbkx-example]::
@@ -37,11 +37,27 @@ Asciidoctor Maven plugin.
 link:java-extension-example/README.adoc[java-extension-example]::
 An example project that demonstrates how to create an extension for Asciidoctorj (written in Java) and how to use it in an other documentation Maven module.
 
+== On JRuby dependency
+
+Asciidoctor Maven plugin relies on https://github.com/asciidoctor/asciidoctor[asciidoctor] project to do the actual rendering. This is a Ruby implementation integrated thanks to the http://jruby.org/[JRuby] project, which is a required dependency to run the plugin. The maven plugin provides a default version of the `jruby-complete` artifact to ease its configuration. However, it can be overwritten just adding a custom version in the plugin's dependency section as seen in the following example:
+```
+    <plugin>
+        <groupId>org.asciidoctor</groupId>
+        <artifactId>asciidoctor-maven-plugin</artifactId>
+        <version>${asciidoctor.maven.plugin.version}</version>
+        <dependencies>
+        	<dependency>
+                <groupId>org.jruby</groupId>
+                <artifactId>jruby-complete</artifactId>
+                <version>${jruby.version}</version>
+            </dependency>
+         <dependencies>
+```  
 
 == Updating Asciidoctor Maven plugin version
 
 In case it is required to test a specific version of the plugin (e.g. local SNAPSHOT version), a tool has been included to update the version in all examples.
-To change the plugin’s version follow the next steps:
+To change the plugin's version follow the next steps:
 
 . Set the desired version in the _<asciidoctor.maven.plugin.version>_ property in the _pom.xml_ file located at the root (asciidoctor-maven-examples folder). For instance:
 

--- a/asciidoc-maven-site-example/pom.xml
+++ b/asciidoc-maven-site-example/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>	
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
         <jruby.version>1.7.20.1</jruby.version>
     </properties>
@@ -28,11 +28,11 @@
                         <version>${asciidoctor.maven.plugin.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
-			        <dependency>
-			            <groupId>org.jruby</groupId>
-			            <artifactId>jruby-complete</artifactId>
-			            <version>${jruby.version}</version>
-			        </dependency>
+                    <dependency>
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby-complete</artifactId>
+                        <version>${jruby.version}</version>
+                    </dependency>
                 </dependencies>
             </plugin>
         </plugins>

--- a/asciidoc-maven-site-example/pom.xml
+++ b/asciidoc-maven-site-example/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>	
-        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.17</jruby.version>
+        <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
+        <jruby.version>1.7.20.1</jruby.version>
     </properties>
 
     <build>
@@ -27,6 +27,12 @@
                         <artifactId>asciidoctor-maven-plugin</artifactId>
                         <version>${asciidoctor.maven.plugin.version}</version>
                     </dependency>
+                    <!-- Comment this section to use the default jruby artifact provided by the plugin -->
+			        <dependency>
+			            <groupId>org.jruby</groupId>
+			            <artifactId>jruby-complete</artifactId>
+			            <version>${jruby.version}</version>
+			        </dependency>
                 </dependencies>
             </plugin>
         </plugins>
@@ -42,7 +48,7 @@
             <plugin>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>2.8</version>
-            </plugin>	
+            </plugin>
         </plugins>
     </reporting>
 

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.17</jruby.version>
+        <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
+        <jruby.version>1.7.20.1</jruby.version>
     </properties>
 
     <build>
@@ -21,22 +21,26 @@
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>${asciidoctor.maven.plugin.version}</version>
-                <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                <!--
-                <dependencies>
-                    <dependency>
-                        <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.2-SNAPSHOT</version>
-                    </dependency>
-                </dependencies>
-                -->
                 <dependencies>
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>1.5.0-alpha.6</version>
+                        <version>1.5.0-alpha.7</version>
                     </dependency>
+                    <!-- Comment this section to use the default jruby artifact provided by the plugin -->
+                    <dependency>
+			            <groupId>org.jruby</groupId>
+			            <artifactId>jruby-complete</artifactId>
+			            <version>${jruby.version}</version>
+			        </dependency>
+                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                	<!--
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj</artifactId>
+                        <version>1.5.3-SNAPSHOT</version>
+                    </dependency>
+                    -->
                 </dependencies>
                 <configuration>
                     <!-- Attributes common to all output formats -->

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -29,12 +29,12 @@
                     </dependency>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
-			            <groupId>org.jruby</groupId>
-			            <artifactId>jruby-complete</artifactId>
-			            <version>${jruby.version}</version>
-			        </dependency>
-                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                	<!--
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby-complete</artifactId>
+                        <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                    <!--
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.17</jruby.version>
+        <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
+        <jruby.version>1.7.20.1</jruby.version>
     </properties>
 
     <build>
@@ -20,17 +20,23 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>${asciidoctor.maven.plugin.version}</version>
-                <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                <!--
+                <version>${asciidoctor.maven.plugin.version}</version>              
                 <dependencies>
+                    <!-- Comment this section to use the default jruby artifact provided by the plugin -->
+                	<dependency>
+			            <groupId>org.jruby</groupId>
+			            <artifactId>jruby-complete</artifactId>
+			            <version>${jruby.version}</version>
+			        </dependency>
+                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                	<!--
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.2-SNAPSHOT</version>
+                        <version>1.5.3-SNAPSHOT</version>
                     </dependency>
+                    -->
                 </dependencies>
-                -->
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>
                     <!-- If you set baseDir to ${project.basedir}, top-level includes are resolved relative to the project root -->

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -23,13 +23,13 @@
                 <version>${asciidoctor.maven.plugin.version}</version>              
                 <dependencies>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
-                	<dependency>
-			            <groupId>org.jruby</groupId>
-			            <artifactId>jruby-complete</artifactId>
-			            <version>${jruby.version}</version>
-			        </dependency>
-                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                	<!--
+                    <dependency>
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby-complete</artifactId>
+                        <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                    <!--
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>

--- a/asciidoctor-diagram-example/README.adoc
+++ b/asciidoctor-diagram-example/README.adoc
@@ -30,10 +30,10 @@ Example:
     <artifactId>asciidoctor-maven-plugin</artifactId>
     ...
     <configuration>
-		<attributes>
-			<graphvizdot>/PATH/TO/Graphviz/bin/dot</graphvizdot>
-		</attributes>
-		...
+        <attributes>
+            <graphvizdot>/PATH/TO/Graphviz/bin/dot</graphvizdot>
+        </attributes>
+        ...
 ----
 
 == References

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -69,13 +69,13 @@
                 <version>${asciidoctor.maven.plugin.version}</version>
                 <dependencies>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
-                	<dependency>
-			            <groupId>org.jruby</groupId>
-			            <artifactId>jruby-complete</artifactId>
-			            <version>${jruby.version}</version>
-			        </dependency>
-                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                	<!--
+                    <dependency>
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby-complete</artifactId>
+                        <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                    <!--
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
@@ -91,14 +91,14 @@
                         <require>asciidoctor-diagram</require>
                     </requires>
                     <attributes>
-						<!-- Example below shows how to specify in this pom instead of System's PATH, the location of dot command of Graphviz, required by PlantUML libraries -->
-						<!-- Windows:
-							<graphvizdot>C:\Program Files (x86)\Graphviz2.38\bin\dot.exe</graphvizdot>
-						-->
-						<!-- *nix :
-							<graphvizdot>/usr/local/bin/dot</graphvizdot>
-						-->
-					</attributes>
+                    <!-- Example below shows how to specify in this pom instead of System's PATH, the location of dot command of Graphviz, required by PlantUML libraries -->
+                    <!-- Windows:
+                        <graphvizdot>C:\Program Files (x86)\Graphviz2.38\bin\dot.exe</graphvizdot>
+                    -->
+                    <!-- *nix :
+                        <graphvizdot>/usr/local/bin/dot</graphvizdot>
+                    -->
+                    </attributes>
                 </configuration>
                 <executions>
                     <execution>

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.17</jruby.version>
+        <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
+        <jruby.version>1.7.20.1</jruby.version>
     </properties>
 
     <repositories>
@@ -67,16 +67,22 @@
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>${asciidoctor.maven.plugin.version}</version>
-                <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                <!--
                 <dependencies>
+                    <!-- Comment this section to use the default jruby artifact provided by the plugin -->
+                	<dependency>
+			            <groupId>org.jruby</groupId>
+			            <artifactId>jruby-complete</artifactId>
+			            <version>${jruby.version}</version>
+			        </dependency>
+                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                	<!--
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.1-SNAPSHOT</version>
+                        <version>1.5.3-SNAPSHOT</version>
                     </dependency>
+                    -->
                 </dependencies>
-                -->
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>
                     <!-- The gem-maven-plugin appends the scope (e.g., provided) to the gemPath defined in the plugin configuration -->

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -28,13 +28,13 @@
                         <version>1.5.0-alpha.7</version>
                     </dependency>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
-                	<dependency>
-			            <groupId>org.jruby</groupId>
-			            <artifactId>jruby-complete</artifactId>
-			            <version>${jruby.version}</version>
-			        </dependency>
-                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                	<!--
+                    <dependency>
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby-complete</artifactId>
+                        <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                    <!--
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.17</jruby.version>
+        <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
+        <jruby.version>1.7.20.1</jruby.version>
     </properties>
 
     <build>
@@ -21,22 +21,26 @@
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>${asciidoctor.maven.plugin.version}</version>
-                <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                <!--
-                <dependencies>
-                    <dependency>
-                        <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.1-SNAPSHOT</version>
-                    </dependency>
-                </dependencies>
-                -->
                 <dependencies>
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>
                         <version>1.5.0-alpha.7</version>
                     </dependency>
+                    <!-- Comment this section to use the default jruby artifact provided by the plugin -->
+                	<dependency>
+			            <groupId>org.jruby</groupId>
+			            <artifactId>jruby-complete</artifactId>
+			            <version>${jruby.version}</version>
+			        </dependency>
+                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                	<!--
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj</artifactId>
+                        <version>1.5.3-SNAPSHOT</version>
+                    </dependency>
+                    -->
                 </dependencies>
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -23,13 +23,13 @@
                 <version>${asciidoctor.maven.plugin.version}</version>
                 <dependencies>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
-                	<dependency>
-			            <groupId>org.jruby</groupId>
-			            <artifactId>jruby-complete</artifactId>
-			            <version>${jruby.version}</version>
-			        </dependency>
-                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                	<!--
+                    <dependency>
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby-complete</artifactId>
+                        <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                    <!--
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.17</jruby.version>
+        <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
+        <jruby.version>1.7.20.1</jruby.version>
     </properties>
 
     <build>
@@ -21,16 +21,22 @@
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>${asciidoctor.maven.plugin.version}</version>
-                <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                <!--
                 <dependencies>
+                    <!-- Comment this section to use the default jruby artifact provided by the plugin -->
+                	<dependency>
+			            <groupId>org.jruby</groupId>
+			            <artifactId>jruby-complete</artifactId>
+			            <version>${jruby.version}</version>
+			        </dependency>
+                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                	<!--
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.1-SNAPSHOT</version>
+                        <version>1.5.3-SNAPSHOT</version>
                     </dependency>
+                    -->
                 </dependencies>
-                -->
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>
                     <!-- If you set baseDir to ${project.basedir}, top-level includes are resolved relative to the project root -->

--- a/docbook-pipeline-jdocbook-example/pom.xml
+++ b/docbook-pipeline-jdocbook-example/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.17</jruby.version>
+        <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
+        <jruby.version>1.7.20.1</jruby.version>
     </properties>
 
     <repositories>
@@ -34,16 +34,22 @@
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <version>${asciidoctor.maven.plugin.version}</version>
-                <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                <!--
                 <dependencies>
+                    <!-- Comment this section to use the default jruby artifact provided by the plugin -->
+                	<dependency>
+			            <groupId>org.jruby</groupId>
+			            <artifactId>jruby-complete</artifactId>
+			            <version>${jruby.version}</version>
+			        </dependency>
+                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                	<!--
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.1-SNAPSHOT</version>
+                        <version>1.5.3-SNAPSHOT</version>
                     </dependency>
+                    -->
                 </dependencies>
-                -->
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>
                     <!-- If you set baseDir to ${project.basedir}, top-level includes are resolved relative to the project root -->

--- a/docbook-pipeline-jdocbook-example/pom.xml
+++ b/docbook-pipeline-jdocbook-example/pom.xml
@@ -36,13 +36,13 @@
                 <version>${asciidoctor.maven.plugin.version}</version>
                 <dependencies>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
-                	<dependency>
-			            <groupId>org.jruby</groupId>
-			            <artifactId>jruby-complete</artifactId>
-			            <version>${jruby.version}</version>
-			        </dependency>
-                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                	<!--
+                    <dependency>
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby-complete</artifactId>
+                        <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                    <!--
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -10,8 +10,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.17</jruby.version>
+        <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
+        <jruby.version>1.7.20.1</jruby.version>
     </properties>
 
     <build>
@@ -28,12 +28,18 @@
                         <artifactId>asciidoctorj-twitter-extension</artifactId>
                         <version>1.0.0-SNAPSHOT</version>
                     </dependency>
-                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                    <!--
+                    <!-- Comment this section to use the default jruby artifact provided by the plugin -->
+                	<dependency>
+			            <groupId>org.jruby</groupId>
+			            <artifactId>jruby-complete</artifactId>
+			            <version>${jruby.version}</version>
+			        </dependency>
+                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                	<!--
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.2-SNAPSHOT</version>
+                        <version>1.5.3-SNAPSHOT</version>
                     </dependency>
                     -->
                 </dependencies>

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -29,13 +29,13 @@
                         <version>1.0.0-SNAPSHOT</version>
                     </dependency>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
-                	<dependency>
-			            <groupId>org.jruby</groupId>
-			            <artifactId>jruby-complete</artifactId>
-			            <version>${jruby.version}</version>
-			        </dependency>
-                	<!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                	<!--
+                    <dependency>
+                        <groupId>org.jruby</groupId>
+                        <artifactId>jruby-complete</artifactId>
+                        <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
+                    <!--
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>

--- a/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacro.java
+++ b/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacro.java
@@ -9,35 +9,33 @@ import org.asciidoctor.extension.InlineMacroProcessor;
 
 public class TwitterMacro extends InlineMacroProcessor {
 
-	public TwitterMacro(String macroName, Map<String, Object> config) {
-		super(macroName, config);
-	}
+    public TwitterMacro(String macroName, Map<String, Object> config) {
+        super(macroName, config);
+    }
 
-	@Override
-	protected Object process(AbstractBlock parent, String twitterHandle,
-			Map<String, Object> attributes) {
+    @Override
+    protected Object process(AbstractBlock parent, String twitterHandle, Map<String, Object> attributes) {
 
-		String twitterLink;
-		String twitterLinkText;
-		if (twitterHandle == null || twitterHandle.isEmpty()) {
-			twitterLink = "http://www.twitter.com/";
-			twitterLinkText = "Twitter";
-		} else {
-			twitterLink = "http://www.twitter.com/" + twitterHandle;
-			// Prepend twitterHandle with @ as text link:
-			twitterLinkText = "@" + twitterHandle;
-		}
+        String twitterLink;
+        String twitterLinkText;
+        if (twitterHandle == null || twitterHandle.isEmpty()) {
+            twitterLink = "http://www.twitter.com/";
+            twitterLinkText = "Twitter";
+        } else {
+            twitterLink = "http://www.twitter.com/" + twitterHandle;
+            // Prepend twitterHandle with @ as text link:
+            twitterLinkText = "@" + twitterHandle;
+        }
 
-		// Define options for an 'anchor' element:
-		Map<String, Object> options = new HashMap<String, Object>();
-		options.put("type", ":link");
-		options.put("target", twitterLink);
+        // Define options for an 'anchor' element:
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put("type", ":link");
+        options.put("target", twitterLink);
 
-		// Create the 'anchor' node:
-		Inline inlineTwitterLink = createInline(parent, "anchor",
-				twitterLinkText, attributes, options);
+        // Create the 'anchor' node:
+        Inline inlineTwitterLink = createInline(parent, "anchor", twitterLinkText, attributes, options);
 
-		// Convert to String value:
-		return inlineTwitterLink.convert();
-	}
+        // Convert to String value:
+        return inlineTwitterLink.convert();
+    }
 }

--- a/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacroExtension.java
+++ b/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacroExtension.java
@@ -6,10 +6,9 @@ import org.asciidoctor.extension.spi.ExtensionRegistry;
 
 public class TwitterMacroExtension implements ExtensionRegistry {
 
-	public void register(Asciidoctor asciidoctor) {
-		JavaExtensionRegistry javaExtensionRegistry = asciidoctor
-				.javaExtensionRegistry();
+    public void register(Asciidoctor asciidoctor) {
+        JavaExtensionRegistry javaExtensionRegistry = asciidoctor.javaExtensionRegistry();
 
-		javaExtensionRegistry.inlineMacro("twitter", TwitterMacro.class);
-	}
+        javaExtensionRegistry.inlineMacro("twitter", TwitterMacro.class);
+    }
 }

--- a/java-extension-example/pom.xml
+++ b/java-extension-example/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.asciidoctor.maven</groupId>
     <artifactId>java-extension-example</artifactId>
     <version>1.0.0-SNAPSHOT</version>
-    <name>Extension example aggreator</name>
+    <name>Extension example aggregator</name>
     <description>The aggregator project for an asciidoc project using an asciidoctorj extension with maven.</description>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.2</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.17</jruby.version>
+        <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
+        <jruby.version>1.7.20.1</jruby.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
This PR includes as main changes:
* Updated plugin version to latest. From 1.5.2 to 1.5.2.1
* Added JRuby dependency in all plugin's configurations (site too)
* Added note on README.adoc about JRuby dependency

And also, the minnor fixes:
* Updated asciidoctorj-pdf dependency to latest in 'multiple-inputs'
* Fixes corrupted quotes in README, back to UTF-8