### PR TITLE
Improve the README of the "java-extension-example" project

### DIFF
--- a/java-extension-example/README.adoc
+++ b/java-extension-example/README.adoc
@@ -14,6 +14,15 @@ With this extension you can write:
 Contact: twitter:mojavelinux[] (project lead lead of the asciidoctor project)
 ----
 
+==== Extension registration
+
+This twitter extension uses the link:https://github.com/asciidoctor/asciidoctorj#extension-spi[SPI interface] to register itself to the Asciidoctor engine.
+
+See the corresponding files:
+
+* link:asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacroExtension.java[TwitterMacroExtension.java]
+* link:asciidoctorj-twitter-extension/src/main/resources/META-INF/services/org.asciidoctor.extension.spi.ExtensionRegistry[org.asciidoctor.extension.spi.ExtensionRegistry]
+
 === asciidoctor-with-extension-example
 
 An example project (very similar to `asciidoc-to-html-example`) that demonstrates how to use the `asciidoctorj-twitter-extension`.


### PR DESCRIPTION
@abelsromero wrote in #20:
> Just a small comment. I think it would be nice to add a few words in the documentation stating it uses the SPI interface. Is it possible?
> Version 1.5.2.1 of the plugin includes other options to register extensions and we may extend the examples in the future with them.

This pull request adds a comment in: `/java-extension-example/README.adoc` with this clarification.

I hope I understood it correctly. Do not hesitate to give me feedback.

