### PR TITLE
Update asciidoctorj-pdf to "1.5.0-alpha.8"

### DIFF
--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -25,7 +25,7 @@
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>1.5.0-alpha.7</version>
+                        <version>1.5.0-alpha.8</version>
                     </dependency>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
@@ -62,7 +62,6 @@
                         <configuration>
                             <sourceDirectory>src/docs/asciidoc/user-manual</sourceDirectory>
                             <backend>pdf</backend>
-                            <!-- WARNING callout bullets don't yet work with CodeRay -->
                             <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
                                 <pagenums/>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -25,7 +25,7 @@
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>1.5.0-alpha.7</version>
+                        <version>1.5.0-alpha.8</version>
                     </dependency>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
@@ -60,11 +60,7 @@
                             <backend>pdf</backend>
                             <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
-                                <!--
-                                WARNING: The font necessary to support font-based icons is missing in AsciidoctorJ PDF 1.5.0-alpha.7.
-                                See https://github.com/asciidoctor/asciidoctorj/issues/330 for details.
                                 <icons>font</icons>
-                                -->
                                 <pagenums/>
                                 <toc/>
                                 <idprefix/>

--- a/asciidoctor-pdf-example/src/docs/asciidoc/example-manual.adoc
+++ b/asciidoctor-pdf-example/src/docs/asciidoc/example-manual.adoc
@@ -19,6 +19,7 @@ We just haven't decided what that is yet.
 ----
 include::{sourcedir}/example/StringUtils.java[tags=contains,indent=0]
 ----
+<1> return statement
 
 This page was built by the following command:
 

--- a/asciidoctor-pdf-example/src/main/java/example/StringUtils.java
+++ b/asciidoctor-pdf-example/src/main/java/example/StringUtils.java
@@ -3,7 +3,7 @@ package example;
 public class StringUtils {
     // tag::contains[]
     public boolean contains(String haystack, String needle) {
-        return haystack.contains(needle);
+        return haystack.contains(needle); //<1>
     }
     // end::contains[]
 }


### PR DESCRIPTION
* Update the version in the pom files.
* Add a callout bullet in the asciidoctor-pdf-example java code.
* Remove outdated warnings in the pom files.
