### PR TITLE
updated asciidoctorj-pdf to 1.5.0-alpha.9 version

### DIFF
--- a/asciidoc-multiple-inputs-example/README.adoc
+++ b/asciidoc-multiple-inputs-example/README.adoc
@@ -30,7 +30,8 @@ In the example, we define a first execution block as follows:
  <configuration>
      <sourceDirectory>src/docs/asciidoc/user-manual</sourceDirectory> <2>
      <backend>pdf</backend> <3>
-     <!-- WARNING callout bullets don't yet work with CodeRay -->
+     <!-- Since 1.5.0-alpha.9, PDF back-end can also use 'rouge' which provides more coverage
+     for other languages like scala -->
      <sourceHighlighter>coderay</sourceHighlighter>
      <attributes>
          <pagenums/>
@@ -53,7 +54,7 @@ You also need to add a dependency on `asciidoctorj-pdf` to make export to PDF wo
 <dependency>
   <groupId>org.asciidoctor</groupId>
   <artifactId>asciidoctorj-pdf</artifactId>
-  <version>1.5.0-alpha.6</version>
+  <version>1.5.0-alpha.9</version>
 </dependency>
 ----
 ====

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -25,7 +25,7 @@
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>1.5.0-alpha.8</version>
+                        <version>1.5.0-alpha.9</version>
                     </dependency>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
@@ -62,6 +62,8 @@
                         <configuration>
                             <sourceDirectory>src/docs/asciidoc/user-manual</sourceDirectory>
                             <backend>pdf</backend>
+                            <!-- Since 1.5.0-alpha.9, PDF back-end can also use 'rouge' which provides more coverage
+                            for other languages like scala -->
                             <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
                                 <pagenums/>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -25,7 +25,7 @@
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>1.5.0-alpha.8</version>
+                        <version>1.5.0-alpha.9</version>
                     </dependency>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
@@ -58,7 +58,9 @@
                         </goals>
                         <configuration>
                             <backend>pdf</backend>
-                            <sourceHighlighter>coderay</sourceHighlighter>
+                            <!-- Since 1.5.0-alpha.9 PDF back-end can use 'rouge' as well as 'coderay'
+                            source highlighting -->
+                            <sourceHighlighter>rouge</sourceHighlighter>
                             <attributes>
                                 <icons>font</icons>
                                 <pagenums/>

--- a/asciidoctor-pdf-example/src/docs/asciidoc/example-manual.adoc
+++ b/asciidoctor-pdf-example/src/docs/asciidoc/example-manual.adoc
@@ -50,3 +50,11 @@ include::subdir/_b.adoc[]
 ====
 
 WARNING: Includes can be tricky!
+
+== Source Code and Syntax Highlighting
+
+This section shows some code highlighting examples.
+
+include::subdir/_code_examples.adoc[]
+
+

--- a/asciidoctor-pdf-example/src/docs/asciidoc/subdir/_code_examples.adoc
+++ b/asciidoctor-pdf-example/src/docs/asciidoc/subdir/_code_examples.adoc
@@ -1,0 +1,94 @@
+=== Ruby example
+
+[source,ruby]
+.Inline Ruby code
+----
+=begin
+This program will
+print "Hello world".
+=end
+
+puts 'Hello world'
+----
+
+=== Java example
+
+[source,java]
+.Inline Java code
+----
+/**
+ * This is a Java "Hello world" example.
+ * @param args arguments
+ *
+ * @since 1.3
+ */
+public class Test {
+  public static void main(String[] args) {
+    System.out.println("Hello World!"); <1>
+  }
+}
+----
+<1> This is where the fun happens
+
+=== Groovy example
+
+[source,groovy]
+.Included Groovy code (from code_snippets/groovy.groovy)
+----
+include::code_snippets/groovy.groovy[]
+----
+
+=== Scala example
+
+[source,scala]
+.Inline Scala code
+----
+/**
+ * This is a simple scala example
+ */
+object HelloWorld {
+  def main(args: Array[String]) {
+    println("Hello, world!")
+  }
+}
+----
+
+=== HTML example
+
+[source,html]
+.Inline HTML code
+----
+<HTML>
+   <head>
+      <title>
+         A Small Hello
+      </title>
+   </head>
+    <body>
+       <h1>Hi</h1>
+       <div class="hello">This is very minimal "hello world" HTML document.</div>
+    </body>
+</HTML>
+----
+
+=== JavaScript example
+
+[source,javascript]
+.Inline JavaScript code
+----
+if (console.log) {
+  // greeting silently
+  console.log('Hello World!!')
+} else {
+  // greeting in a pop up window
+  alert('Hello World!')
+}
+----
+
+=== CoffeeScript example
+
+[source,coffeescript]
+.Included CoffeeScript code (from code_snippets/coffeeScript.coffee)
+----
+include::code_snippets/coffeeScript.coffee[]
+----

--- a/asciidoctor-pdf-example/src/docs/asciidoc/subdir/code_snippets/coffeeScript.coffee
+++ b/asciidoctor-pdf-example/src/docs/asciidoc/subdir/code_snippets/coffeeScript.coffee
@@ -1,0 +1,28 @@
+# Assignment:
+number   = 42
+opposite = true
+
+# Conditions:
+number = -42 if opposite
+
+# Functions:
+square = (x) -> x * x
+
+# Arrays:
+list = [1, 2, 3, 4, 5]
+
+# Objects:
+math =
+  root:   Math.sqrt
+  square: square
+  cube:   (x) -> x * square x
+
+# Splats:
+race = (winner, runners...) ->
+  print winner, runners
+
+# Existence:
+alert "I knew it!" if elvis?
+
+# Array comprehensions:
+cubes = (math.cube num for num in list)

--- a/asciidoctor-pdf-example/src/docs/asciidoc/subdir/code_snippets/groovy.groovy
+++ b/asciidoctor-pdf-example/src/docs/asciidoc/subdir/code_snippets/groovy.groovy
@@ -1,0 +1,9 @@
+def printHello (toWho = "World") {
+    println "Hello $toWho!!"
+}
+
+// Passing some value
+printHello('Asciidoctor')
+
+// Using default value
+printHello()


### PR DESCRIPTION
This PR contains:
* Updated version of asciidoctorj-pdf to 1.5.0-alpha.9 in `asciidoctor-pdf-example` and `asciidoc-multiple-inputs-example`.
* Added source code examples to the PDF example (`asciidoctor-pdf-example`).
* Added comments in POM's about usage of coderay and rouge.
Minnor updated.
* Minnor update in `asciidoctor-pdf-example` README to remove a comment about callouts in coderay. Tested, they do work.