### PR TITLE
Fix "ifndef::sourcedir" line

### DIFF
--- a/asciidoc-multiple-inputs-example/src/docs/asciidoc/technical-docs/example-technical-doc.adoc
+++ b/asciidoc-multiple-inputs-example/src/docs/asciidoc/technical-docs/example-technical-doc.adoc
@@ -4,7 +4,7 @@ Doc Writer <doc.writer@example.org>
 :revnumber: {project-version}
 :example-caption!:
 ifndef::imagesdir[:imagesdir: images]
-ifndef::sourcedir[:sourcedir: ../java]
+ifndef::sourcedir[:sourcedir: ../../../main/java]
 
 This is the technical documentation for an example project.
 

--- a/asciidoc-multiple-inputs-example/src/docs/asciidoc/user-manual/example-manual.adoc
+++ b/asciidoc-multiple-inputs-example/src/docs/asciidoc/user-manual/example-manual.adoc
@@ -4,7 +4,7 @@ Doc Writer <doc.writer@example.org>
 :revnumber: {project-version}
 :example-caption!:
 ifndef::imagesdir[:imagesdir: images]
-ifndef::sourcedir[:sourcedir: ../java]
+ifndef::sourcedir[:sourcedir: ../../../main/java]
 
 This is a user manual for an example project.
 

--- a/asciidoc-to-html-example/src/docs/asciidoc/example-manual.adoc
+++ b/asciidoc-to-html-example/src/docs/asciidoc/example-manual.adoc
@@ -4,7 +4,7 @@ Doc Writer <doc.writer@example.org>
 :revnumber: {project-version}
 :example-caption!:
 ifndef::imagesdir[:imagesdir: images]
-ifndef::sourcedir[:sourcedir: ../java]
+ifndef::sourcedir[:sourcedir: ../../main/java]
 
 This is a user manual for an example project.
 

--- a/asciidoc-to-revealjs-example/src/docs/asciidoc/slides.adoc
+++ b/asciidoc-to-revealjs-example/src/docs/asciidoc/slides.adoc
@@ -4,7 +4,7 @@ Doc Writer <doc.writer@example.org>
 :revnumber: {project-version}
 :example-caption!:
 ifndef::imagesdir[:imagesdir: images]
-ifndef::sourcedir[:sourcedir: ../java]
+ifndef::sourcedir[:sourcedir: ../../main/java]
 
 == Introduction
 

--- a/asciidoctor-diagram-example/src/docs/asciidoc/example-manual.adoc
+++ b/asciidoctor-diagram-example/src/docs/asciidoc/example-manual.adoc
@@ -3,7 +3,6 @@ Doc Writer <doc.writer@example.org>
 v1.0, 2014-09-09
 :example-caption!:
 ifndef::imagesdir[:imagesdir: images]
-ifndef::sourcedir[:sourcedir: ../java]
 
 This is a user manual for an example project.
 

--- a/asciidoctor-pdf-example/src/docs/asciidoc/example-manual.adoc
+++ b/asciidoctor-pdf-example/src/docs/asciidoc/example-manual.adoc
@@ -3,7 +3,7 @@ Doc Writer <doc.writer@example.org>
 v1.0, 2014-09-09
 :example-caption!:
 ifndef::imagesdir[:imagesdir: images]
-ifndef::sourcedir[:sourcedir: ../java]
+ifndef::sourcedir[:sourcedir: ../../main/java]
 
 This is a user manual for an example project.
 

--- a/docbook-pipeline-docbkx-example/src/docs/asciidoc/example-manual.adoc
+++ b/docbook-pipeline-docbkx-example/src/docs/asciidoc/example-manual.adoc
@@ -3,7 +3,7 @@ Doc Writer <doc.writer@example.org>
 v1.0, 2014-09-09
 :example-caption!:
 ifndef::imagesdir[:imagesdir: images]
-ifndef::sourcedir[:sourcedir: ../java]
+ifndef::sourcedir[:sourcedir: ../../main/java]
 
 This is a user manual for an example project.
 

--- a/docbook-pipeline-jdocbook-example/src/docs/asciidoc/example-manual.adoc
+++ b/docbook-pipeline-jdocbook-example/src/docs/asciidoc/example-manual.adoc
@@ -3,7 +3,7 @@ Doc Writer <doc.writer@example.org>
 v1.0, 2014-09-09
 :example-caption!:
 ifndef::imagesdir[:imagesdir: images]
-ifndef::sourcedir[:sourcedir: ../java]
+ifndef::sourcedir[:sourcedir: ../../main/java]
 
 This is a user manual for an example project.
 


### PR DESCRIPTION
The line was everywhere:

    ifndef::sourcedir[:sourcedir: ../java]

This is wrong, because the java folder is not there.

With this fix, the `adoc` files can be correctly previewed (in Chrome for example).