### PR TITLE
Update dependencies to the latest version

### DIFF
--- a/asciidoc-maven-site-example/pom.xml
+++ b/asciidoc-maven-site-example/pom.xml
@@ -12,7 +12,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.20.1</jruby.version>
+        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <jruby.version>9.0.4.0</jruby.version>
     </properties>
 
     <build>
@@ -32,6 +33,12 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby-complete</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj</artifactId>
+                        <version>${asciidoctorj.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -11,7 +11,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.20.1</jruby.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.10.1</asciidoctorj.pdf.version>
+        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <jruby.version>9.0.4.0</jruby.version>
     </properties>
 
     <build>
@@ -25,7 +27,7 @@
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>1.5.0-alpha.9</version>
+                        <version>${asciidoctorj.pdf.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
@@ -33,14 +35,12 @@
                         <artifactId>jruby-complete</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
-                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                    <!--
+                    <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.3-SNAPSHOT</version>
+                        <version>${asciidoctorj.version}</version>
                     </dependency>
-                    -->
                 </dependencies>
                 <configuration>
                     <!-- Attributes common to all output formats -->

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -11,7 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.20.1</jruby.version>
+        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <jruby.version>9.0.4.0</jruby.version>
     </properties>
 
     <build>
@@ -28,14 +29,12 @@
                         <artifactId>jruby-complete</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
-                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                    <!--
+                    <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.3-SNAPSHOT</version>
+                        <version>${asciidoctorj.version}</version>
                     </dependency>
-                    -->
                 </dependencies>
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>

--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -12,7 +12,8 @@
         <project.slides.directory>${project.build.directory}/generated-slides</project.slides.directory>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.20.1</jruby.version>
+        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <jruby.version>9.0.4.0</jruby.version>
         <revealjs.version>3.1.0</revealjs.version>
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
     </properties>
@@ -64,14 +65,12 @@
                         <artifactId>jruby-complete</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
-                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                    <!--
+                    <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.3-SNAPSHOT</version>
+                        <version>${asciidoctorj.version}</version>
                     </dependency>
-                    -->
                 </dependencies>
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -11,7 +11,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.20.1</jruby.version>
+        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <jruby.version>9.0.4.0</jruby.version>
+        <rubygems.asciidoctor.diagram.version>1.3.1</rubygems.asciidoctor.diagram.version>
     </properties>
 
     <repositories>
@@ -31,7 +33,7 @@
         <dependency>
             <groupId>rubygems</groupId>
             <artifactId>asciidoctor-diagram</artifactId>
-            <version>1.2.1</version>
+            <version>${rubygems.asciidoctor.diagram.version}</version>
             <type>gem</type>
             <scope>provided</scope>
             <exclusions>
@@ -51,7 +53,7 @@
                 <version>1.0.10</version>
                 <configuration>
                     <!-- align JRuby version with AsciidoctorJ to avoid redundant downloading -->
-                    <jrubyVersion>1.7.9</jrubyVersion>
+                    <jrubyVersion>${jruby.version}</jrubyVersion>
                     <gemHome>${project.build.directory}/gems</gemHome>
                     <gemPath>${project.build.directory}/gems</gemPath>
                 </configuration>
@@ -74,14 +76,12 @@
                         <artifactId>jruby-complete</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
-                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                    <!--
+                    <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.3-SNAPSHOT</version>
+                        <version>${asciidoctorj.version}</version>
                     </dependency>
-                    -->
                 </dependencies>
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -11,7 +11,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.20.1</jruby.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.10.1</asciidoctorj.pdf.version>
+        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <jruby.version>9.0.4.0</jruby.version>
     </properties>
 
     <build>
@@ -25,7 +27,7 @@
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj-pdf</artifactId>
-                        <version>1.5.0-alpha.9</version>
+                        <version>${asciidoctorj.pdf.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
@@ -33,14 +35,12 @@
                         <artifactId>jruby-complete</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
-                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                    <!--
+                    <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.3-SNAPSHOT</version>
+                        <version>${asciidoctorj.version}</version>
                     </dependency>
-                    -->
                 </dependencies>
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -11,7 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.20.1</jruby.version>
+        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <jruby.version>9.0.4.0</jruby.version>
     </properties>
 
     <build>
@@ -28,14 +29,12 @@
                         <artifactId>jruby-complete</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
-                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                    <!--
+                    <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.3-SNAPSHOT</version>
+                        <version>${asciidoctorj.version}</version>
                     </dependency>
-                    -->
                 </dependencies>
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>

--- a/docbook-pipeline-jdocbook-example/pom.xml
+++ b/docbook-pipeline-jdocbook-example/pom.xml
@@ -11,7 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.20.1</jruby.version>
+        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <jruby.version>9.0.4.0</jruby.version>
     </properties>
 
     <repositories>
@@ -41,14 +42,12 @@
                         <artifactId>jruby-complete</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
-                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                    <!--
+                    <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.3-SNAPSHOT</version>
+                        <version>${asciidoctorj.version}</version>
                     </dependency>
-                    -->
                 </dependencies>
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -11,7 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.20.1</jruby.version>
+        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <jruby.version>9.0.4.0</jruby.version>
     </properties>
 
     <build>
@@ -34,14 +35,12 @@
                         <artifactId>jruby-complete</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
-                    <!-- Uncomment the following element to override the version of AsciidoctorJ -->
-                    <!--
+                    <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctorj</artifactId>
-                        <version>1.5.3-SNAPSHOT</version>
+                        <version>${asciidoctorj.version}</version>
                     </dependency>
-                    -->
                 </dependencies>
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
-        <jruby.version>1.7.20.1</jruby.version>
+        <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
+        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.10.1</asciidoctorj.pdf.version>
+        <jruby.version>9.0.4.0</jruby.version>
+        <rubygems.asciidoctor.diagram.version>1.3.1</rubygems.asciidoctor.diagram.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
I have set the dependencies to:

* AsciidoctorJ => 1.5.3.2
* AsciidoctorJ PDF => 1.5.0-alpha.10.1
* AsciidoctorJ Diagram => 1.3.1
* JRuby => 9.0.4.0

I have introduced properties to fix the version.

Discussion on the Mailing List:
http://discuss.asciidoctor.org/1-5-3-2-release-amp-Maven-plugin-td4059.html