### PR TITLE
Add a graphviz example in asciidoctor-diagram-example

### DIFF
--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.2.1</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
-        <jruby.version>9.0.4.0</jruby.version>
+        <jruby.version>1.7.21</jruby.version><!-- downgrade of JRuby see: https://github.com/asciidoctor/asciidoctorj/issues/409 -->
         <rubygems.asciidoctor.diagram.version>1.3.1</rubygems.asciidoctor.diagram.version>
     </properties>
 

--- a/asciidoctor-diagram-example/src/docs/asciidoc/example-manual.adoc
+++ b/asciidoctor-diagram-example/src/docs/asciidoc/example-manual.adoc
@@ -42,6 +42,16 @@ Alice -> Bob: Another authentication Request
 Alice <-- Bob: another authentication Response
 ....
 
+[graphviz, dot-example, svg]
+----
+digraph g {
+    a -> b
+    b -> c
+    c -> d
+    d -> a
+}
+----
+
 == Attributes
 
 .Built-in


### PR DESCRIPTION
I think it is important to have a graphviz dot example in the Maven example, as mentioned here: 
[Plain-text diagrams take shape in Asciidoctor!](http://asciidoctor.org/news/2014/02/18/plain-text-diagrams-in-asciidoctor/)

Due to [asciidoctorj/issues/409](https://github.com/asciidoctor/asciidoctorj/issues/409) I needed to downgrade the JRuby version.

Related discussion on the mailing list:
http://discuss.asciidoctor.org/Dot-Graphviz-format-in-Asciidoctor-diagram-in-a-maven-build-td4067.html
