### PR TITLE
Set asciidoctorj version to 1.5.4

### DIFF
--- a/asciidoc-maven-site-example/pom.xml
+++ b/asciidoc-maven-site-example/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <asciidoctor.maven.plugin.version>1.5.3</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.version>1.5.4</asciidoctorj.version>
         <jruby.version>9.0.4.0</jruby.version>
     </properties>
 

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.3</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.10.1</asciidoctorj.pdf.version>
-        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.11</asciidoctorj.pdf.version>
+        <asciidoctorj.version>1.5.4</asciidoctorj.version>
         <jruby.version>9.0.4.0</jruby.version>
     </properties>
 

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.3</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.version>1.5.4</asciidoctorj.version>
         <jruby.version>9.0.4.0</jruby.version>
     </properties>
 

--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -12,7 +12,7 @@
         <project.slides.directory>${project.build.directory}/generated-slides</project.slides.directory>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.3</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.version>1.5.4</asciidoctorj.version>
         <jruby.version>9.0.4.0</jruby.version>
         <revealjs.version>3.1.0</revealjs.version>
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.3</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.version>1.5.4</asciidoctorj.version>
         <asciidoctorj.diagram.version>1.3.1</asciidoctorj.diagram.version>
         <jruby.version>1.7.21</jruby.version><!-- downgrade of JRuby see: https://github.com/asciidoctor/asciidoctorj/issues/409 -->
     </properties>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.3</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.10.1</asciidoctorj.pdf.version>
-        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.11</asciidoctorj.pdf.version>
+        <asciidoctorj.version>1.5.4</asciidoctorj.version>
         <jruby.version>9.0.4.0</jruby.version>
     </properties>
 

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.3</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.10.1</asciidoctorj.pdf.version>
-        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.11</asciidoctorj.pdf.version>
+        <asciidoctorj.version>1.5.4</asciidoctorj.version>
         <jruby.version>9.0.4.0</jruby.version>
         <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     </properties>

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.3</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.version>1.5.4</asciidoctorj.version>
         <jruby.version>9.0.4.0</jruby.version>
     </properties>
 

--- a/docbook-pipeline-jdocbook-example/pom.xml
+++ b/docbook-pipeline-jdocbook-example/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.3</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.version>1.5.4</asciidoctorj.version>
         <jruby.version>9.0.4.0</jruby.version>
     </properties>
 

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.3</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.version>1.5.4</asciidoctorj.version>
         <jruby.version>9.0.4.0</jruby.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.3</asciidoctor.maven.plugin.version>
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
-        <asciidoctorj.version>1.5.3.2</asciidoctorj.version>
+        <asciidoctorj.version>1.5.4</asciidoctorj.version>
         <asciidoctorj.diagram.version>1.3.1</asciidoctorj.diagram.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.10.1</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.11</asciidoctorj.pdf.version>
         <jruby.version>9.0.4.0</jruby.version>
         <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     </properties>


### PR DESCRIPTION
I have updated the examples to use the latest AsciidoctorJ version (1.5.4).

I have noticed no unexpected differences in the outputs (I have compared the HTML files between version 1.5.3.2 and 1.5.4)
