### PR TITLE
Updated 'update-properties' script to accept command line arguments

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -76,7 +76,18 @@ Asciidoctor Maven plugin relies on https://github.com/asciidoctor/asciidoctor[as
 == Updating Asciidoctor Maven plugin version
 
 In case it is required to test a specific version of the plugin (e.g. local SNAPSHOT version), a tool has been included to update the version in all examples.
-To change the plugin's version follow the next steps:
+Properties can be updated in two ways.
+
+* First, define the new versions using the `versions` system property, this will update in examples as well as in the parent.
+The following example shows how to update two properties.
+
+[source,indent=2]
+----
+$ mvn validate -Pupdate-properties -Dversions=asciidoctor.maven.plugin.version=1.6.0-SNAPSHOT,asciidoctorj.pdf.version=1.5.0-alpha.12
+----
+
+* Secondly, copying the properties values from the parent pom to the example projects.
+For example, to change the plugin's version follow the next steps:
 
 . Set the desired version in the _<asciidoctor.maven.plugin.version>_ property in the _pom.xml_ file located at the root (asciidoctor-maven-examples folder). For instance:
 

--- a/update-properties.groovy
+++ b/update-properties.groovy
@@ -4,36 +4,77 @@
  * This script is made as an alternative to `versions-maven-plugin`, which 
  * validates versions and does not allow to use local installed snapshots :(
  */
-import groovy.io.FileType;
+import ParsingUtils as parser
+import CommandLineUtils as commandLine
 
 def root = new File('.')
-
-/* parent properties parsing */
 def parentPom = new XmlSlurper().parse(new File(root,'pom.xml'))
-def replacements = [:]
-parentPom.properties.children().each {
-    if (it.name().endsWith('version')) {
-        replacements["${it.name()}>"] = it.text()
+// parent properties parsing
+def replacements = parser.findReplacements(parentPom)
+replacements << commandLine.getVersionProperties()
+println replacements
+// updates
+parser.updateProjects(root, replacements)
+
+commandLine.getVersionProperties()
+
+class CommandLineUtils {
+
+    static Map getVersionProperties () {
+        def properties = [:]
+        if (System.getProperty("versions")) {
+            System.getProperty("versions").split(",").each { p ->
+                def (k, v) = p.split("=")
+                properties["${k}>"] = v
+            }
+        }
+        properties
     }
 }
 
-if (replacements.size() > 0) {
-    println "[INFO] Found ${replacements.size()} properties to update:"
-    replacements.each { k, v ->
-        println "[INFO]\t\t${k[0..-2]} = $v"
-    }
-}
 
-/* child pom's update */
-root.eachDirRecurse { folder ->
-    folder.listFiles({it.name == 'pom.xml'} as FileFilter).each { File pom ->
+// Create class to avoid naming problems with the hyphen in the script name
+class ParsingUtils {
+
+    /**
+     * Returns a map with the different candidates (properties with values) to update
+     */
+    static Map findReplacements(def pom) {
+        def replacements = [:]
+        pom.properties.children().each {
+            if (it.name().endsWith('version')) {
+                replacements["${it.name()}>"] = it.text()
+            }
+        }
+
+        if (replacements.size() > 0) {
+            println "[INFO] Found ${replacements.size()} candidate properties to update:"
+            replacements.each { k, v ->
+                println "[INFO]\t\t${k[0..-2]} = $v"
+            }
+        }
+        replacements
+    }
+
+    /**
+     * Child pom's update
+     */
+    static void updateProjects(File rootFolder, def properties) {
+        rootFolder.eachDirRecurse { folder ->
+            folder.listFiles({ it.name == 'pom.xml' } as FileFilter).each {
+                updatePom(it, properties)
+            }
+        }
+    }
+
+    static void updatePom(File pom, def properties) {
         // println "[INFO] Parsing ${pom.absolutePath}"
-        File copy = new File(pom.absolutePath+'-TEMP')
-        copy.withWriter('UTF-8')  { writer ->
-            pom.eachLine ('UTF-8') { line ->
-                replacements.each { k, v ->
+        File copy = new File(pom.absolutePath + '-TEMP')
+        copy.withWriter('UTF-8') { writer ->
+            pom.eachLine('UTF-8') { line ->
+                properties.each { k, v ->
                     if (line.contains(k)) {
-                        // println "[INFO] Updating property ${k[0..-2]}" 
+                        // println "[INFO] Updating property ${k[0..-2]}"
                         line = "${line.split(k)[0]}$k$v</$k"
                     }
                 }
@@ -44,4 +85,5 @@ root.eachDirRecurse { folder ->
         pom.delete()
         copy.renameTo(pom)
     }
+
 }


### PR DESCRIPTION
This PR makes easier to update the version properties adding a command line option.
The main motivations for this change are two:
* Make changes faster to reduce the update time after releases. For instance, after AsciidoctorJ.
* Offer an interface that can be automated at some point.