### PR TITLE
Prawn requires new JRuby

### DIFF
--- a/asciidoctor-pdf-with-theme-example/README.adoc
+++ b/asciidoctor-pdf-with-theme-example/README.adoc
@@ -13,4 +13,4 @@ Convert the AsciiDoc to PDF using Asciidoctor PDF by invoking the `process-resou
 
  $ mvn
 
-Open the file _target/generated-docs/example-manual.pdf_ in your PDF viewer to see the generated PDF.
+Open the file _target/generated-docs-custom-theme/example-manual.pdf_ in your PDF viewer to see the generated PDF.

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -13,7 +13,7 @@
         <asciidoctor.maven.plugin.version>1.5.3</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>1.5.0-alpha.11</asciidoctorj.pdf.version>
         <asciidoctorj.version>1.5.4</asciidoctorj.version>
-        <jruby.version>1.7.21</jruby.version>
+        <jruby.version>9.0.5.0</jruby.version>
         <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     </properties>
 


### PR DESCRIPTION
When using this example (only after clean!) I get the error:

    3306 [INFO] --- gem-maven-plugin:1.0.10:initialize (default) @ asciidoctor-pdf-with-theme-example ---
    16187 [INFO] ERROR:  Error installing .m2\repository\rubygems\prawn\2.0.2\prawn-2.0.2.gem:
    16187 [INFO]    prawn requires Ruby version >= 2.0.0.
    17435 [INFO] Successfully installed ttfunk-1.4.0
    17845 [INFO] Successfully installed pdf-core-0.6.1
    17899 [INFO] BUILD FAILURE

Updating the JRuby dependency fixes this.