### PR TITLE
Update asciidoctorj-pdf

### DIFF
--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.5</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.14</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.15</asciidoctorj.pdf.version>
         <asciidoctorj.version>1.5.5</asciidoctorj.version>
         <jruby.version>1.7.26</jruby.version>
     </properties>

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.5</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>1.5.5</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.14</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.15</asciidoctorj.pdf.version>
         <jruby.version>9.1.8.0</jruby.version>
         <pdf.cjk.version>0.1.3</pdf.cjk.version>
         <pdf.cjk.kaigen.version>0.1.1</pdf.cjk.kaigen.version>

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -139,7 +139,7 @@
                             <backend>pdf</backend>
                             <sourceDirectory>src/docs/asciidoc</sourceDirectory>
                             <sourceDocumentName>README-zh_CN.adoc</sourceDocumentName>
-                            <sourceHighlighter>rouge</sourceHighlighter>
+                            <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
                                 <allow-uri-read/>
                                 <icons>font</icons>
@@ -162,7 +162,7 @@
                             <backend>pdf</backend>
                             <sourceDirectory>src/docs/asciidoc</sourceDirectory>
                             <sourceDocumentName>README-jp.adoc</sourceDocumentName>
-                            <sourceHighlighter>rouge</sourceHighlighter>
+                            <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
                                 <allow-uri-read/>
                                 <icons>font</icons>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.5</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.14</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.15</asciidoctorj.pdf.version>
         <asciidoctorj.version>1.5.5</asciidoctorj.version>
         <jruby.version>1.7.26</jruby.version>
     </properties>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -59,8 +59,13 @@
                         <configuration>
                             <backend>pdf</backend>
                             <!-- Since 1.5.0-alpha.9 PDF back-end can use 'rouge' as well as 'coderay'
-                            source highlighting -->
-                            <sourceHighlighter>rouge</sourceHighlighter>
+                            for source highlighting -->
+                            <!-- Due to a known issue on windows, it is recommended to use 'coderay' until an new version of 'rouge' is released.
+                                    see discussions: https://github.com/asciidoctor/asciidoctor-maven-examples/pull/58
+                                                     https://github.com/asciidoctor/asciidoctorj-pdf/issues/3
+                                                     https://github.com/jneen/rouge/issues/661
+                            -->
+                            <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
                                 <icons>font</icons>
                                 <pagenums/>

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -11,56 +11,14 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>1.5.5</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.14</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.15</asciidoctorj.pdf.version>
         <asciidoctorj.version>1.5.5</asciidoctorj.version>
         <jruby.version>9.1.8.0</jruby.version>
-        <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     </properties>
-
-    <repositories>
-        <repository>
-            <id>rubygems-proxy-releases</id>
-            <name>RubyGems.org Proxy (Releases)</name>
-            <url>http://rubygems-proxy.torquebox.org/releases</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <dependencies>
-        <dependency>
-            <groupId>rubygems</groupId>
-            <artifactId>prawn</artifactId>
-            <version>${rubygems.prawn.version}</version>
-            <type>gem</type>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
 
     <build>
         <defaultGoal>process-resources</defaultGoal>
         <plugins>
-            <plugin>
-                <groupId>de.saumya.mojo</groupId>
-                <artifactId>gem-maven-plugin</artifactId>
-                <version>1.0.10</version>
-                <configuration>
-                    <!-- align JRuby version with AsciidoctorJ to avoid redundant downloading -->
-                    <jrubyVersion>${jruby.version}</jrubyVersion>
-                    <gemHome>${project.build.directory}/gems</gemHome>
-                    <gemPath>${project.build.directory}/gems</gemPath>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>initialize</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
@@ -86,8 +44,6 @@
                 </dependencies>
                 <configuration>
                     <sourceDirectory>src/docs/asciidoc</sourceDirectory>
-                    <!-- The gem-maven-plugin appends the scope (e.g., provided) to the gemPath defined in the plugin configuration -->
-                    <gemPath>${project.build.directory}/gems-provided</gemPath>
                     <!-- Attributes common to all output formats -->
                     <attributes>
                         <sourcedir>${project.build.sourceDirectory}</sourcedir>

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -59,7 +59,7 @@
                         <configuration>
                             <backend>pdf</backend>
                             <outputDirectory>${project.build.directory}/generated-docs-default-theme</outputDirectory>
-                            <sourceHighlighter>rouge</sourceHighlighter>
+                            <sourceHighlighter>coderay</sourceHighlighter>
                             <doctype>book</doctype>
                             <attributes>
                                 <icons>font</icons>
@@ -79,7 +79,7 @@
                         <configuration>
                             <backend>pdf</backend>
                             <outputDirectory>${project.build.directory}/generated-docs-custom-theme</outputDirectory>
-                            <sourceHighlighter>rouge</sourceHighlighter>
+                            <sourceHighlighter>coderay</sourceHighlighter>
                             <doctype>book</doctype>
                             <attributes>
                                 <pdf-stylesdir>${project.basedir}/src/theme</pdf-stylesdir>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
         <asciidoctorj.version>1.5.5</asciidoctorj.version>
         <asciidoctorj.diagram.version>1.5.4</asciidoctorj.diagram.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.14</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.15</asciidoctorj.pdf.version>
         <jruby.version>1.7.26</jruby.version>
         <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     </properties>


### PR DESCRIPTION
Update asciidoctorj-pdf to "1.5.0-alpha.15" and remove usage of "rubygems" approach in the "pdf-with-theme-example" project