### PR TITLE
Upgrade to use new reveal.js version

### DIFF
--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -14,7 +14,7 @@
         <asciidoctor.maven.plugin.version>1.5.5</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>1.5.6</asciidoctorj.version>
         <jruby.version>1.7.26</jruby.version>
-        <revealjs.version>3.1.0</revealjs.version>
+        <revealjs.version>3.5.0</revealjs.version>
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
     </properties>
 


### PR DESCRIPTION
Would be cool if example has new version of reveal.js because the new version makes the speaker notes page better. 
https://github.com/asciidoctor/asciidoctor-reveal.js/issues/137