### PR TITLE
Use reveal.js stable version instead of master

### DIFF
--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -15,7 +15,8 @@
         <asciidoctorj.version>1.5.6</asciidoctorj.version>
         <jruby.version>1.7.26</jruby.version>
         <revealjs.version>3.5.0</revealjs.version>
-        <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
+        <!-- Use 'master' as version and remove the 'v' prefixing the download url to use the current snapshot version  -->
+        <asciidoctor-revealjs.version>1.0.4</asciidoctor-revealjs.version>
     </properties>
 
     <build>
@@ -24,7 +25,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.2.1</version>
+                <version>1.3.0</version>
                 <executions>
                     <execution>
                         <id>install-asciidoctor-revealjs</id>
@@ -33,7 +34,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://github.com/asciidoctor/asciidoctor-reveal.js/archive/${asciidoctor-revealjs.version}.zip</url>
+                            <url>https://github.com/asciidoctor/asciidoctor-reveal.js/archive/v${asciidoctor-revealjs.version}.zip</url>
                             <unpack>true</unpack>
                             <outputFileName>asciidoctor-reveal.js-${asciidoctor-revealjs.version}.zip</outputFileName>
                             <outputDirectory>${project.build.directory}</outputDirectory>


### PR DESCRIPTION
As discussed https://github.com/asciidoctor/asciidoctor-maven-examples/issues/62 the current reveal.js example uses the current version in master `asciidoctor-reveal.js`. This makes build not reproducible unless one clean the cache, and may affect the example due to temporal changes in master.
That why, this PR changes the example to use the released version instead.

This PR also updates the `download-maven-plugin` to latest version.