### PR TITLE
update examples to Asciidoctorj v2.0.0

### DIFF
--- a/asciidoc-maven-site-example/pom.xml
+++ b/asciidoc-maven-site-example/pom.xml
@@ -11,9 +11,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
-        <jruby.version>9.1.17.0</jruby.version>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <jruby.version>9.2.7.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -10,12 +10,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.16</asciidoctorj.pdf.version>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
-        <jruby.version>9.1.17.0</jruby.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.17</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <jruby.version>9.2.7.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -10,11 +10,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
-        <jruby.version>9.1.17.0</jruby.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <jruby.version>9.2.7.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -11,14 +11,14 @@
     <properties>
         <project.slides.directory>${project.build.directory}/generated-slides</project.slides.directory>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
-        <jruby.version>9.1.17.0</jruby.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <jruby.version>9.2.7.0</jruby.version>
         <revealjs.version>3.5.0</revealjs.version>
         <!-- Use 'master' as version and remove the 'v' prefixing the download url to use the current snapshot version  -->
-        <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
+        <asciidoctor-revealjs.version>2.0.0</asciidoctor-revealjs.version>
     </properties>
 
     <build>
@@ -36,7 +36,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
-                            <url>https://github.com/asciidoctor/asciidoctor-reveal.js/archive/${asciidoctor-revealjs.version}.zip</url>
+                            <url>https://github.com/asciidoctor/asciidoctor-reveal.js/archive/v${asciidoctor-revealjs.version}.zip</url>
                             <unpack>true</unpack>
                             <outputFileName>asciidoctor-reveal.js-${asciidoctor-revealjs.version}.zip</outputFileName>
                             <outputDirectory>${project.build.directory}</outputDirectory>

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -10,10 +10,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
         <asciidoctorj.diagram.version>1.5.16</asciidoctorj.diagram.version>
-        <jruby.version>9.1.17.0</jruby.version>
+        <jruby.version>9.2.7.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoctor-epub-example/pom.xml
+++ b/asciidoctor-epub-example/pom.xml
@@ -12,13 +12,13 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.epub.version>1.5.0-alpha.8.1</asciidoctorj.epub.version>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.epub.version>1.5.0-alpha.9</asciidoctorj.epub.version>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
         <!-- for a correct kf8 generation, you'll need at least jRuby >= 9.1.8.0 -->
-        <jruby.version>9.1.17.0</jruby.version>
+        <jruby.version>9.2.7.0</jruby.version>
         <!-- provide full path to kindlegen application if you need the fallback solution -->
         <path.to.kindlegen>/absolute/path/to/kindlegen</path.to.kindlegen>
     </properties>

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -12,12 +12,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.16</asciidoctorj.pdf.version>
-        <jruby.version>9.1.17.0</jruby.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.17</asciidoctorj.pdf.version>
+        <jruby.version>9.2.7.0</jruby.version>
         <pdf.cjk.version>0.1.3</pdf.cjk.version>
         <pdf.cjk.kaigen.version>0.1.1</pdf.cjk.kaigen.version>
     </properties>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -10,12 +10,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.16</asciidoctorj.pdf.version>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
-        <jruby.version>9.1.17.0</jruby.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.17</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <jruby.version>9.2.7.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -10,12 +10,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.16</asciidoctorj.pdf.version>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
-        <jruby.version>9.1.17.0</jruby.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.17</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <jruby.version>9.2.7.0</jruby.version>
     </properties>
 
     <build>

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -10,11 +10,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
-        <jruby.version>9.1.17.0</jruby.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <jruby.version>9.2.7.0</jruby.version>
     </properties>
 
     <build>

--- a/docbook-pipeline-jdocbook-example/pom.xml
+++ b/docbook-pipeline-jdocbook-example/pom.xml
@@ -10,11 +10,11 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
-        <jruby.version>9.1.17.0</jruby.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <jruby.version>9.2.7.0</jruby.version>
     </properties>
 
     <repositories>

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -10,9 +10,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
-        <jruby.version>9.1.17.0</jruby.version>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <jruby.version>9.2.7.0</jruby.version>
     </properties>
 
     <build>

--- a/java-extension-example/asciidoctorj-twitter-extension/pom.xml
+++ b/java-extension-example/asciidoctorj-twitter-extension/pom.xml
@@ -10,9 +10,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
     </properties>
 
     <dependencies>

--- a/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacro.java
+++ b/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacro.java
@@ -1,20 +1,20 @@
 package org.asciidoctorj.twitter.extension;
 
+import org.asciidoctor.ast.ContentNode;
+import org.asciidoctor.ast.PhraseNode;
+import org.asciidoctor.extension.InlineMacroProcessor;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import org.asciidoctor.ast.AbstractBlock;
-import org.asciidoctor.ast.Inline;
-import org.asciidoctor.extension.InlineMacroProcessor;
-
 public class TwitterMacro extends InlineMacroProcessor {
 
-    public TwitterMacro(String macroName, Map<String, Object> config) {
-        super(macroName, config);
+    public TwitterMacro(String macroName) {
+        super(macroName);
     }
 
     @Override
-    public Object process(AbstractBlock parent, String twitterHandle, Map<String, Object> attributes) {
+    public Object process(ContentNode contentNode, String twitterHandle, Map<String, Object> attributes) {
 
         String twitterLink;
         String twitterLinkText;
@@ -28,14 +28,14 @@ public class TwitterMacro extends InlineMacroProcessor {
         }
 
         // Define options for an 'anchor' element:
-        Map<String, Object> options = new HashMap<String, Object>();
+        Map<String, Object> options = new HashMap<>();
         options.put("type", ":link");
         options.put("target", twitterLink);
 
         // Create the 'anchor' node:
-        Inline inlineTwitterLink = createInline(parent, "anchor", twitterLinkText, attributes, options);
+        ContentNode inlineTwitterLink = createPhraseNode(contentNode, "anchor", twitterLinkText, attributes, options);
 
         // Convert to String value:
-        return inlineTwitterLink.convert();
+        return ((PhraseNode) inlineTwitterLink).convert();
     }
 }

--- a/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacro.java
+++ b/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacro.java
@@ -33,9 +33,9 @@ public class TwitterMacro extends InlineMacroProcessor {
         options.put("target", twitterLink);
 
         // Create the 'anchor' node:
-        ContentNode inlineTwitterLink = createPhraseNode(contentNode, "anchor", twitterLinkText, attributes, options);
+        PhraseNode inlineTwitterLink = createPhraseNode(contentNode, "anchor", twitterLinkText, attributes, options);
 
         // Convert to String value:
-        return ((PhraseNode) inlineTwitterLink).convert();
+        return inlineTwitterLink.convert();
     }
 }

--- a/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacroExtension.java
+++ b/java-extension-example/asciidoctorj-twitter-extension/src/main/java/org/asciidoctorj/twitter/extension/TwitterMacroExtension.java
@@ -2,13 +2,13 @@ package org.asciidoctorj.twitter.extension;
 
 import org.asciidoctor.Asciidoctor;
 import org.asciidoctor.extension.JavaExtensionRegistry;
-import org.asciidoctor.extension.spi.ExtensionRegistry;
+import org.asciidoctor.jruby.extension.spi.ExtensionRegistry;
 
 public class TwitterMacroExtension implements ExtensionRegistry {
 
     public void register(Asciidoctor asciidoctor) {
         JavaExtensionRegistry javaExtensionRegistry = asciidoctor.javaExtensionRegistry();
-
         javaExtensionRegistry.inlineMacro("twitter", TwitterMacro.class);
     }
+
 }

--- a/java-extension-example/asciidoctorj-twitter-extension/src/main/resources/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry
+++ b/java-extension-example/asciidoctorj-twitter-extension/src/main/resources/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry
@@ -1,0 +1,2 @@
+# File: src/main/resources/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry
+org.asciidoctorj.twitter.extension.TwitterMacroExtension

--- a/pom.xml
+++ b/pom.xml
@@ -13,13 +13,12 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>1.5.7.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
-        <asciidoctorj.version>1.5.8.1</asciidoctorj.version>
+        <asciidoctorj.version>2.0.0</asciidoctorj.version>
         <asciidoctorj.diagram.version>1.5.16</asciidoctorj.diagram.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.16</asciidoctorj.pdf.version>
-        <!-- use 9.2.6.0 when using Asciidoctorj 1.6.x -->
-        <jruby.version>9.1.17.0</jruby.version>
+        <asciidoctorj.pdf.version>1.5.0-alpha.17</asciidoctorj.pdf.version>
+        <jruby.version>9.2.7.0</jruby.version>
         <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     </properties>
 


### PR DESCRIPTION
Also includes updates to last versions of:
* Asciidoctorj-pdf
* Asciidoctorj-epub
* jRuby-complete
* asciidoctor-reveal.js

Note that minimum Java version is now 8.