### PR TITLE
Upgrade asciidoctorj v210 asciidoctorj pdf v150beta6 j ruby v9280

### DIFF
--- a/asciidoc-maven-site-example/pom.xml
+++ b/asciidoc-maven-site-example/pom.xml
@@ -12,8 +12,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
+        <jruby.version>9.2.8.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -13,9 +13,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.18</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <asciidoctorj.pdf.version>1.5.0-beta.6</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
+        <jruby.version>9.2.8.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
+        <jruby.version>9.2.8.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -14,11 +14,11 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
+        <jruby.version>9.2.8.0</jruby.version>
         <revealjs.version>3.8.0</revealjs.version>
         <!-- Use 'master' as version and remove the 'v' prefixing the download url to use the current snapshot version  -->
-        <asciidoctor-revealjs.version>2.0.0</asciidoctor-revealjs.version>
+        <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
     </properties>
 
     <dependencies>

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -11,9 +11,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
         <asciidoctorj.diagram.version>1.5.18</asciidoctorj.diagram.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <jruby.version>9.2.8.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoctor-epub-example/README.adoc
+++ b/asciidoctor-epub-example/README.adoc
@@ -1,4 +1,5 @@
 = Asciidoctor Maven Plugin: AsciiDoc to EPUB Example
+:kindlegen-download-url: https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211
 
 An example project that demonstrates how to convert AsciiDoc to EPUB using Asciidoctor EPUB3 with the Asciidoctor Maven plugin.
 
@@ -6,7 +7,9 @@ An example project that demonstrates how to convert AsciiDoc to EPUB using Ascii
 
 === EPUB
 
-Convert the AsciiDoc to EPUB using Asciidoctor EPUB3 by invoking the `process-resources` goal (configured as the default goal):
+This examples requires providing the path to `kindlegen` in the `KINDLEGEN` environment variable (you have to download it for your OS from amazon here: {kindlegen-download-url})).
+
+Once done, convert the AsciiDoc to EPUB using https://github.com/asciidoctor/asciidoctor-epub3/[Asciidoctor EPUB3] by invoking the `process-resources` goal (configured as the default goal):
 
  $ mvn
 
@@ -14,5 +17,7 @@ Open the file _target/generated-docs/spine.epub_ in your epub viewer to see the 
 
 === MOBI
 
-If you want to generate a kindle document, you can enable a second execution block in the pom.xml. If _kindlegen_ is in your path (you have to download it for your OS from amazon here: https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211) a mobi file should be generated. Currently however the maven plugin exits with an error ((Errno::ECHILD) No child processes)).
+There is a second process available to generate a kindle document, you can enable a second execution block in the pom.xml.
+If _kindlegen_ is in your path a mobi file should be generated.
+Currently however the maven plugin exits with an error _((Errno::ECHILD) No child processes))_.
 

--- a/asciidoctor-epub-example/pom.xml
+++ b/asciidoctor-epub-example/pom.xml
@@ -16,9 +16,9 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
         <asciidoctorj.epub.version>1.5.0-alpha.9</asciidoctorj.epub.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
         <!-- for a correct kf8 generation, you'll need at least jRuby >= 9.1.8.0 -->
-        <jruby.version>9.2.7.0</jruby.version>
+        <jruby.version>9.2.8.0</jruby.version>
         <!-- provide full path to kindlegen application if you need the fallback solution -->
         <path.to.kindlegen>/absolute/path/to/kindlegen</path.to.kindlegen>
     </properties>

--- a/asciidoctor-pdf-cjk-example/README.adoc
+++ b/asciidoctor-pdf-cjk-example/README.adoc
@@ -2,9 +2,18 @@
 :cn-example-file: README-zh_CN
 :jp-example-file: README-jp
 
-An example project that demonstrates how to convert AsciiDoc to PDF using CJK extensions to properly show CJK (Chinese, Japanese and Korean) characters.
+An example project that demonstrates how to convert AsciiDoc to PDF using https://github.com/chloerei/asciidoctor-pdf-cjk[asciidoctor-pdf-cjk] and https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic[asciidoctor-pdf-cjk-kai_gen_gothic] resources to properly show CJK (Chinese, Japanese and Korean) characters.
 
 == Usage
+
+[IMPORTANT]
+====
+Since asciidoctorj-pdf v.1.5.0.beta.2 `asciidoctor-pdf-cjk` and `asciidoctor-pdf-cjk-kai_gen_gothic` gems are no longer compatible.
+And while asciidoctor-pdf has evolved to no longer depend on these, the resources contained (theme and fonts) are still of great help to achieve quality documentation for the languages supported.
+
+That's why this example no longer uses the gems, but shows how to import the resources required using maven tools.
+We encourage you to experiment with custom themes and additional fonts to suite special needs not supported by this example.
+====
 
 Convert the AsciiDoc to PDF using Asciidoctor PDF by invoking the `process-resources` goal (configured as the default goal):
 
@@ -13,33 +22,3 @@ Convert the AsciiDoc to PDF using Asciidoctor PDF by invoking the `process-resou
 Open the generated files _target/generated-docs/{cn-example-file}.pdf_ and _target/generated-docs/{jp-example-file}.pdf_ in your PDF viewer to see the generated PDFs.
 
 The examples used are the Chinese and Japanese translations of the Asciidoctor README document (all found link:https://github.com/asciidoctor/asciidoctor/[here]). Contributed respectively by link:https://github.com/diguage[diguage] and link:https://github.com/Mizuho32[Mizuho32].
-
-== Used Asciidoctor extensions
-
-This project uses two Ruby extensions by link:https://github.com/chloerei[Rei] (link:https://twitter.com/chloerei[@chloerei]):
-
-link:https://github.com/chloerei/asciidoctor-pdf-cjk[Asciidoctor PDF CJK]::
-Fixes line wraps formatting inserting zero-width spaces (ZWSP) before CJ characters.
-
-link:https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic[KaiGen Gothic Asciidoctor Theme]::
-Contains style improvements as well as a much wider set of Hanzi and Kanji characters not found in the default fonts.
-
-[NOTE]
-====
-`KaiGen Gothic Asciidoctor Theme` extension downloads 183 MB in required TTF fonts on every build into the target directory.
-It would be advisable to cache those files in a real project.
-////
-Use this in `asciidoctor-pdf-cjk-example/target/gems-provided/gems/asciidoctor-pdf-cjk-kai_gen_gothic-0.1.1/exe/asciidoctor-pdf-cjk-kai_gen_gothic-install` to cache files.
-
-Dir.chdir(FontsDir) do
-  Fonts.each_with_index do |name, index|
-    puts "[#{index + 1}/#{Fonts.count}] Downloading #{name}"
-    unless File.exist?(name)
-      File.open(name, 'wb') do |file|
-        file.write open("https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic/releases/download/v0.1.0-fonts/#{name}").read
-      end
-    end
-  end
-end
-////
-====

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -6,8 +6,9 @@
     <artifactId>asciidoctor-pdf-cjk-example</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <name>Asciidoctor PDF CJK Maven example</name>
-    <description>An example project that demonstrates how to convert AsciiDoc to PDF using CJK extensions to properly
-        show CJK (Chinese, Japanese and Korean) characters.
+    <description>
+        An example project that demonstrates how to convert AsciiDoc to PDF using CJK resources
+        (https://github.com/chloerei/asciidoctor-pdf-cjk) to properly show CJK (Chinese, Japanese and Korean) characters.
     </description>
 
     <properties>
@@ -15,89 +16,197 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.18</asciidoctorj.pdf.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
+        <asciidoctorj.pdf.version>1.5.0-beta.6</asciidoctorj.pdf.version>
+        <jruby.version>9.2.8.0</jruby.version>
         <pdf.cjk.version>0.1.3</pdf.cjk.version>
         <pdf.cjk.kaigen.version>0.1.1</pdf.cjk.kaigen.version>
+        <pdf.cjk.kaigen.fonts.download.uri>https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic/releases/download/v0.1.0-fonts</pdf.cjk.kaigen.fonts.download.uri>
+        <pdf.cjk.kaigen.themes.download.uri>https://raw.githubusercontent.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic/master/data/themes</pdf.cjk.kaigen.themes.download.uri>
+        <pdf.cjk.kaigen.download.dir>${project.build.directory}/downloaded-resources</pdf.cjk.kaigen.download.dir>
     </properties>
-
-    <repositories>
-        <repository>
-            <id>rubygems-release</id>
-            <url>http://rubygems-proxy.torquebox.org/releases</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <dependencies>
-        <dependency>
-            <groupId>rubygems</groupId>
-            <artifactId>asciidoctor-pdf-cjk</artifactId>
-            <version>${pdf.cjk.version}</version>
-            <type>gem</type>
-            <!-- avoid downloading gems included in AsciidoctorJ -->
-            <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>rubygems</groupId>
-                    <artifactId>asciidoctor</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>rubygems</groupId>
-                    <artifactId>asciidoctor-pdf</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>rubygems</groupId>
-            <artifactId>asciidoctor-pdf-cjk-kai_gen_gothic</artifactId>
-            <version>${pdf.cjk.kaigen.version}</version>
-            <type>gem</type>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
 
     <build>
         <defaultGoal>process-resources</defaultGoal>
         <plugins>
             <plugin>
-                <groupId>de.saumya.mojo</groupId>
-                <artifactId>gem-maven-plugin</artifactId>
-                <version>1.1.5</version>
-                <configuration>
-                    <skip>true</skip>
-                    <!-- Align JRuby version with AsciidoctorJ to avoid redundant downloading -->
-                    <jrubyVersion>${jruby.version}</jrubyVersion>
-                    <gemHome>${project.build.directory}/gems</gemHome>
-                    <gemPath>${project.build.directory}/gems</gemPath>
-                </configuration>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.3.0</version>
                 <executions>
-                    <!-- Install required gems in target directory -->
+                    <!-- Chinese theme & fonts -->
                     <execution>
-                        <id>install-gems</id>
-                        <goals>
-                            <goal>initialize</goal>
-                        </goals>
+                        <id>install-theme-KaiGenGothicCN</id>
                         <phase>initialize</phase>
-                    </execution>
-                    <!-- Download KaiGen Gothic fonts in target directory -->
-                    <execution>
-                        <id>install-themes</id>
                         <goals>
-                            <goal>exec</goal>
+                            <goal>wget</goal>
                         </goals>
-                        <phase>initialize</phase>
                         <configuration>
-                            <!-- Run post-installation script to download fonts -->
-                            <execArgs>${project.build.directory}/gems-provided/gems/asciidoctor-pdf-cjk-kai_gen_gothic-${pdf.cjk.kaigen.version}/exe/asciidoctor-pdf-cjk-kai_gen_gothic-install</execArgs>
+                            <url>${pdf.cjk.kaigen.themes.download.uri}/KaiGenGothicCN-theme.yml</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/themes</outputDirectory>
+                            <md5>8f40b658f32767456efba0267eb13c81</md5>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-font-KaiGenGothicCN-Bold-Italic</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${pdf.cjk.kaigen.fonts.download.uri}/KaiGenGothicCN-Bold-Italic.ttf</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/fonts</outputDirectory>
+                            <md5>131053dc1e9b83c04a1604e9b8fbd2ff</md5>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-font-KaiGenGothicCN-Bold</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${pdf.cjk.kaigen.fonts.download.uri}/KaiGenGothicCN-Bold.ttf</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/fonts</outputDirectory>
+                            <md5>151442028333ac1fe314eed4c5fdb39a</md5>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-font-KaiGenGothicCN-Regular-Italic</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${pdf.cjk.kaigen.fonts.download.uri}/KaiGenGothicCN-Regular-Italic.ttf</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/fonts</outputDirectory>
+                            <md5>9747163e814b7b6301e32b3838a0f8c8</md5>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-font-KaiGenGothicCN-Regular</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${pdf.cjk.kaigen.fonts.download.uri}/KaiGenGothicCN-Regular.ttf</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/fonts</outputDirectory>
+                            <md5>1dbdd22db9a1748e38e31698a5d9130a</md5>
+                        </configuration>
+                    </execution>
+                    <!-- Japanese theme & fonts -->
+                    <execution>
+                        <id>install-theme-KaiGenGothicJP</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${pdf.cjk.kaigen.themes.download.uri}/KaiGenGothicJP-theme.yml</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/themes</outputDirectory>
+                            <md5>33ae321471a2fc6e312b8744fdf6fbc0</md5>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-font-KaiGenGothicJP-Bold-Italic</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${pdf.cjk.kaigen.fonts.download.uri}/KaiGenGothicJP-Bold-Italic.ttf</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/fonts</outputDirectory>
+                            <md5>527bad63e68f4765933241949d760bd7</md5>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-font-KaiGenGothicJP-Bold</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${pdf.cjk.kaigen.fonts.download.uri}/KaiGenGothicJP-Bold.ttf</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/fonts</outputDirectory>
+                            <md5>65b2313bd3e3ff54ded1c5875245b8e3</md5>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-font-KaiGenGothicJP-Regular-Italic</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${pdf.cjk.kaigen.fonts.download.uri}/KaiGenGothicJP-Regular-Italic.ttf</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/fonts</outputDirectory>
+                            <md5>2aea70e601c0304f1337319b63b06b7a</md5>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-font-KaiGenGothicJP-Regular</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${pdf.cjk.kaigen.fonts.download.uri}/KaiGenGothicJP-Regular.ttf</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/fonts</outputDirectory>
+                            <md5>a623c6aaf9ba3c992ecd10698586da62</md5>
+                        </configuration>
+                    </execution>
+                    <!-- RobotoMono Fonts -->
+                    <execution>
+                        <id>install-font-RobotoMono-Bold-Italic</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${pdf.cjk.kaigen.fonts.download.uri}/RobotoMono-BoldItalic.ttf</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/fonts</outputDirectory>
+                            <md5>28c34883fca976c0d408c1a0a8596ece</md5>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-font-RobotoMono-Bold</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${pdf.cjk.kaigen.fonts.download.uri}/RobotoMono-Bold.ttf</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/fonts</outputDirectory>
+                            <md5>cf661842dcc7e1cc63147893ea8f47e8</md5>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-font-RobotoMono-Italic</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${pdf.cjk.kaigen.fonts.download.uri}/RobotoMono-Italic.ttf</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/fonts</outputDirectory>
+                            <md5>7b4c715c7e2b43e8f001c601f4fecbb0</md5>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-font-RobotoMono-Regular</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${pdf.cjk.kaigen.fonts.download.uri}/RobotoMono-Regular.ttf</url>
+                            <outputDirectory>${pdf.cjk.kaigen.download.dir}/fonts</outputDirectory>
+                            <md5>e2642a6882ef2432ee9ac442691a4384</md5>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
-
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
@@ -121,15 +230,6 @@
                         <version>${asciidoctorj.version}</version>
                     </dependency>
                 </dependencies>
-                <configuration>
-                    <!-- The gem-maven-plugin appends the scope (e.g., provided) to the gemPath defined in the plugin configuration -->
-                    <gemPath>${project.build.directory}/gems-provided</gemPath>
-                    <!-- Set Ruby extensions as required gems -->
-                    <requires>
-                        <require>asciidoctor-pdf-cjk</require>
-                        <require>asciidoctor-pdf-cjk-kai_gen_gothic</require>
-                    </requires>
-                </configuration>
                 <executions>
                     <execution>
                         <id>generate-pdf-cjk-zh_CN-doc</id>
@@ -149,8 +249,12 @@
                                 <toc/>
                                 <idprefix/>
                                 <idseparator>-</idseparator>
+                                <!-- Fixes line wraps formatting inserting zero-width spaces (ZWSP) before CJ characters -->
+                                <scripts>cjk</scripts>
                                 <!-- Set KaiGen Gothic Chinese theme -->
                                 <pdf-style>KaiGenGothicCN</pdf-style>
+                                <pdf-stylesdir>${pdf.cjk.kaigen.download.dir}/themes</pdf-stylesdir>
+                                <pdf-fontsdir>${pdf.cjk.kaigen.download.dir}/fonts</pdf-fontsdir>
                             </attributes>
                         </configuration>
                     </execution>
@@ -172,8 +276,12 @@
                                 <toc/>
                                 <idprefix/>
                                 <idseparator>-</idseparator>
+                                <!-- Fixes line wraps formatting inserting zero-width spaces (ZWSP) before CJ characters -->
+                                <scripts>cjk</scripts>
                                 <!-- Set KaiGen Gothic Japanese theme -->
                                 <pdf-style>KaiGenGothicJP</pdf-style>
+                                <pdf-stylesdir>${pdf.cjk.kaigen.download.dir}/themes</pdf-stylesdir>
+                                <pdf-fontsdir>${pdf.cjk.kaigen.download.dir}/fonts</pdf-fontsdir>
                             </attributes>
                         </configuration>
                     </execution>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -13,9 +13,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.18</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <asciidoctorj.pdf.version>1.5.0-beta.6</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
+        <jruby.version>9.2.8.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -13,9 +13,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.18</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <asciidoctorj.pdf.version>1.5.0-beta.6</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
+        <jruby.version>9.2.8.0</jruby.version>
     </properties>
 
     <build>
@@ -82,6 +82,7 @@
                             <backend>pdf</backend>
                             <outputDirectory>${project.build.directory}/generated-docs-custom-theme</outputDirectory>
                             <sourceHighlighter>coderay</sourceHighlighter>
+                            <!-- Use `book` docType to enable title page generation -->
                             <doctype>book</doctype>
                             <attributes>
                                 <pdf-stylesdir>${project.basedir}/src/theme</pdf-stylesdir>

--- a/asciidoctor-pdf-with-theme-example/src/theme/custom-theme.yml
+++ b/asciidoctor-pdf-with-theme-example/src/theme/custom-theme.yml
@@ -1,43 +1,44 @@
-title_page:
+title-page:
   align: left
-  background_image: cover.png
-
+  logo:
+    image: image:cover.png[align=center]
+    top: 0%
 page:
   layout: portrait
   margin: [0.75in, 1in, 0.75in, 1in]
   size: A4
 base:
-  font_color: #333333
-  line_height_length: 17
-  line_height: $base_line_height_length / $base_font_size
-vertical_rhythm: $base_line_height_length
+  font-color: #333333
+  line-height-length: 20
+  line-height: $base-line-height-length / $base-font-size
 heading:
-  font_color: #FF8000
-  font_size: 17
-  font_style: bold
-  line_height: 1.2
-  margin_bottom: $vertical_rhythm
+  font-color: #FF8000
+  font-size: 12
+  font-style: bold
+  line-height: 1.2
 link:
-  font_color: #009900
-outline_list:
-  indent: $base_font_size * 1.5
+  font-color: #009900
 header:
   height: 0.75in
-  line_height: 1
-  recto_content:
-    center: '{document-title}'
-  verso_content:
-    center: '{document-title}'
+  line-height: 1
+  recto:
+    right:
+      content: '{document-title}'
+  verso:
+    left:
+      content: '{document-title}'
 footer:
   height: 0.75in
-  line_height: 1
-  recto_content:
-    right: '{chapter-title} | *{page-number}*'
-  verso_content:
-    left: '*{page-number}* | {chapter-title}'
+  line-height: 1
+  recto:
+    right:
+      content: '{chapter-title} | *{page-number}*'
+  verso:
+    left:
+      content: '*{page-number}* | {chapter-title}'
 image:
   align: center
 caption:
   align: center
-  font_color: #FF0000
-  font_size: 10
+  font-color: #FF0000
+  font-size: 10

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
+        <jruby.version>9.2.8.0</jruby.version>
     </properties>
 
     <build>

--- a/docbook-pipeline-jdocbook-example/pom.xml
+++ b/docbook-pipeline-jdocbook-example/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
+        <jruby.version>9.2.8.0</jruby.version>
     </properties>
 
     <repositories>

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
+        <jruby.version>9.2.8.0</jruby.version>
     </properties>
 
     <build>

--- a/java-extension-example/asciidoctorj-twitter-extension/pom.xml
+++ b/java-extension-example/asciidoctorj-twitter-extension/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
-        <asciidoctorj.version>2.0.0</asciidoctorj.version>
+        <asciidoctorj.version>2.1.0</asciidoctorj.version>
         <asciidoctorj.diagram.version>1.5.18</asciidoctorj.diagram.version>
-        <asciidoctorj.pdf.version>1.5.0-alpha.18</asciidoctorj.pdf.version>
-        <jruby.version>9.2.7.0</jruby.version>
+        <asciidoctorj.pdf.version>1.5.0-beta.6</asciidoctorj.pdf.version>
+        <jruby.version>9.2.8.0</jruby.version>
         <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     </properties>
 


### PR DESCRIPTION
Upgrades versions:
* Asciidoctorj 2.0.0 -> 2.1.0
* Asciidoctor-pdf 1.5.0-alpha.18 -> 1.5.0-beta.6
* Jruby 9.2.7.0 -> 9.2.8.0

Additionally:
* Updated asciidoctor-pdf theme configuration.
* Updated asciidoctor-pdf-cjk-example to work without need of third party gems and download fonts using maven tools.
* Document configuration requirements for epub3 conversion in README.
