### PR TITLE
bumps versions: asciidoctorj 2.3.0, jruby 9.2.11.1, asciidoctorj-pdf 1.5.3, asciidoctorj-diagram 2.0.2

### DIFF
--- a/asciidoc-maven-site-example/pom.xml
+++ b/asciidoc-maven-site-example/pom.xml
@@ -12,8 +12,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <jruby.version>9.2.11.1</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -13,9 +13,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-rc.3</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <jruby.version>9.2.11.1</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <jruby.version>9.2.11.1</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -14,8 +14,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <jruby.version>9.2.11.1</jruby.version>
         <revealjs.version>3.8.0</revealjs.version>
         <!-- Use 'master' as version and remove the 'v' prefixing the download url to use the current snapshot version  -->
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -11,9 +11,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
-        <asciidoctorj.diagram.version>2.0.1</asciidoctorj.diagram.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <asciidoctorj.diagram.version>2.0.2</asciidoctorj.diagram.version>
+        <jruby.version>9.2.11.1</jruby.version>
     </properties>
 
     <build>

--- a/asciidoctor-epub-example/pom.xml
+++ b/asciidoctor-epub-example/pom.xml
@@ -16,9 +16,9 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
         <asciidoctorj.epub.version>1.5.0-alpha.13</asciidoctorj.epub.version>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <!-- for a correct kf8 generation, you'll need at least jRuby >= 9.1.8.0 -->
-        <jruby.version>9.2.9.0</jruby.version>
+        <jruby.version>9.2.11.1</jruby.version>
         <!-- provide full path to kindlegen application if you need the fallback solution -->
         <path.to.kindlegen>/absolute/path/to/kindlegen</path.to.kindlegen>
     </properties>

--- a/asciidoctor-epub-example/src/docs/asciidoc/spine.adoc
+++ b/asciidoctor-epub-example/src/docs/asciidoc/spine.adoc
@@ -14,6 +14,7 @@ ifndef::source-highlighter[:source-highlighter: coderay]
 //:ebook-format: kf8
 
 include::example-manual.adoc[]
-include::chapter2.adoc[]
-include::chapter3.adoc[]
 
+include::chapter2.adoc[]
+
+include::chapter3.adoc[]

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -16,9 +16,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.5.0-rc.3</asciidoctorj.pdf.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
+        <jruby.version>9.2.11.1</jruby.version>
         <pdf.cjk.version>0.1.3</pdf.cjk.version>
         <pdf.cjk.kaigen.version>0.1.1</pdf.cjk.kaigen.version>
         <pdf.cjk.kaigen.fonts.download.uri>https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic/releases/download/v0.1.0-fonts</pdf.cjk.kaigen.fonts.download.uri>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -13,9 +13,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-rc.3</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <jruby.version>9.2.11.1</jruby.version>
     </properties>
 
     <build>

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -13,9 +13,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.0-rc.3</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <jruby.version>9.2.11.1</jruby.version>
     </properties>
 
     <build>

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <jruby.version>9.2.11.1</jruby.version>
     </properties>
 
     <build>

--- a/docbook-pipeline-jdocbook-example/pom.xml
+++ b/docbook-pipeline-jdocbook-example/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <jruby.version>9.2.11.1</jruby.version>
     </properties>
 
     <repositories>

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <jruby.version>9.2.11.1</jruby.version>
     </properties>
 
     <build>

--- a/java-extension-example/asciidoctorj-twitter-extension/pom.xml
+++ b/java-extension-example/asciidoctorj-twitter-extension/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
-        <asciidoctorj.version>2.2.0</asciidoctorj.version>
-        <asciidoctorj.diagram.version>2.0.1</asciidoctorj.diagram.version>
-        <asciidoctorj.pdf.version>1.5.0-rc.3</asciidoctorj.pdf.version>
-        <asciidoctorj.epub.version>1.5.0-alpha.13</asciidoctorj.epub.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <asciidoctorj.version>2.3.0</asciidoctorj.version>
+        <asciidoctorj.diagram.version>2.0.2</asciidoctorj.diagram.version>
+        <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
+        <asciidoctorj.epub.version>1.5.0-alpha.16</asciidoctorj.epub.version>
+        <jruby.version>9.2.11.1</jruby.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Bumps versions:
* asciidoctorj to 2.3.0
* jruby 9.2.11.1
* asciidoctorj-pdf 1.5.3
* asciidoctorj-diagram 2.0.2


The epub example complains about sources formats, need to look further.
