### PR TITLE
bump asciidoctorj-epub example to v1.5.0-alpha.16 + fix warnings

### DIFF
--- a/asciidoctor-epub-example/README.adoc
+++ b/asciidoctor-epub-example/README.adoc
@@ -1,4 +1,4 @@
-= Asciidoctor Maven Plugin: AsciiDoc to EPUB Example
+:leveloffset: +1= Asciidoctor Maven Plugin: AsciiDoc to EPUB Example
 :kindlegen-download-url: https://www.amazon.com/gp/feature.html?ie=UTF8&docId=1000765211
 
 An example project that demonstrates how to convert AsciiDoc to EPUB using Asciidoctor EPUB3 with the Asciidoctor Maven plugin.
@@ -7,7 +7,7 @@ An example project that demonstrates how to convert AsciiDoc to EPUB using Ascii
 
 === EPUB
 
-This examples requires providing the path to `kindlegen` in the `KINDLEGEN` environment variable (you have to download it for your OS from amazon here: {kindlegen-download-url})).
+This example requires providing the path to `kindlegen` in the `KINDLEGEN` environment variable (you have to download it for your OS from amazon here: {kindlegen-download-url}).
 
 Once done, convert the AsciiDoc to EPUB using https://github.com/asciidoctor/asciidoctor-epub3/[Asciidoctor EPUB3] by invoking the `process-resources` goal (configured as the default goal):
 
@@ -19,5 +19,3 @@ Open the file _target/generated-docs/spine.epub_ in your epub viewer to see the 
 
 There is a second process available to generate a kindle document, you can enable a second execution block in the pom.xml.
 If _kindlegen_ is in your path a mobi file should be generated.
-Currently however the maven plugin exits with an error _((Errno::ECHILD) No child processes))_.
-

--- a/asciidoctor-epub-example/pom.xml
+++ b/asciidoctor-epub-example/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
-        <asciidoctorj.epub.version>1.5.0-alpha.13</asciidoctorj.epub.version>
+        <asciidoctorj.epub.version>1.5.0-alpha.16</asciidoctorj.epub.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <!-- for a correct kf8 generation, you'll need at least jRuby >= 9.1.8.0 -->
         <jruby.version>9.2.11.1</jruby.version>

--- a/asciidoctor-epub-example/src/docs/asciidoc/spine.adoc
+++ b/asciidoctor-epub-example/src/docs/asciidoc/spine.adoc
@@ -10,6 +10,7 @@ ifndef::imagesdir[:imagesdir: images]
 :front-cover-image: image:cover.png[Front cover,1050,1600]
 ifndef::ebook-format[:leveloffset: -1]
 ifndef::source-highlighter[:source-highlighter: coderay]
+:leveloffset: +1
 //add following line if you want to create a .mobi file (or set it in pom.xml)
 //:ebook-format: kf8
 


### PR DESCRIPTION
* Bumps asciidoctorj-epub to latest 1.5.0-alpha.16
* Fix warning that appear after .5.0-alpha.14 with `leveloffset`
* Remove notice about possible errors in example's readme