### PR TITLE
bumps asciidoctor-maven-plugin to v2.0.0 + fix revealjs with older jruby

### DIFF
--- a/asciidoc-maven-site-example/pom.xml
+++ b/asciidoc-maven-site-example/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <jruby.version>9.2.11.1</jruby.version>
     </properties>

--- a/asciidoc-multiple-inputs-example/README.adoc
+++ b/asciidoc-multiple-inputs-example/README.adoc
@@ -28,12 +28,12 @@ In the example, we define a first execution block as follows:
      <goal>process-asciidoc</goal>
  </goals>
  <configuration>
-     <sourceDirectory>src/docs/asciidoc/user-manual</sourceDirectory> <2>
-     <backend>pdf</backend> <3>
+     <sourceDirectory>src/docs/asciidoc/user-manual</sourceDirectory> <!--2-->
+     <backend>pdf</backend> <!--3-->
      <!-- Since 1.5.0-alpha.9, PDF back-end can also use 'rouge' which provides more coverage
      for other languages like scala -->
-     <sourceHighlighter>coderay</sourceHighlighter>
      <attributes>
+        <source-highlighter>coderay</source-highlighter>
          <pagenums/>
          <toc/>
          <idprefix/>
@@ -70,10 +70,10 @@ The second execution block defines how to create the technical documentation in 
         <goal>process-asciidoc</goal>
     </goals>
     <configuration>
-        <sourceDirectory>src/docs/asciidoc/technical-docs</sourceDirectory> <2>
-        <backend>html5</backend> <3>
-        <sourceHighlighter>coderay</sourceHighlighter>
+        <sourceDirectory>src/docs/asciidoc/technical-docs</sourceDirectory> <!--2-->
+        <backend>html5</backend> <!--3-->
         <attributes>
+            <source-highlighter>coderay</source-highlighter>
             <imagesdir>./images</imagesdir>
             <toc>left</toc>
             <icons>font</icons>

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <jruby.version>9.2.11.1</jruby.version>
@@ -66,8 +66,8 @@
                             <backend>pdf</backend>
                             <!-- Since 1.5.0-alpha.9, PDF back-end can also use 'rouge' which provides more coverage
                             for other languages like scala -->
-                            <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
+                                <source-highlighter>coderay</source-highlighter>
                                 <pagenums/>
                                 <toc/>
                                 <idprefix/>
@@ -84,8 +84,8 @@
                         <configuration>
                             <sourceDirectory>src/docs/asciidoc/technical-docs</sourceDirectory>
                             <backend>html5</backend>
-                            <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
+                                <source-highlighter>coderay</source-highlighter>
                                 <imagesdir>./images</imagesdir>
                                 <toc>left</toc>
                                 <icons>font</icons>

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <jruby.version>9.2.11.1</jruby.version>
     </properties>
@@ -60,7 +60,6 @@
                         </goals>
                         <configuration>
                             <backend>html5</backend>
-                            <sourceHighlighter>coderay</sourceHighlighter>
                             <!--
                             Scenarios for linking vs embedding assets:
 
@@ -111,6 +110,7 @@
                             IMPORTANT: When you enable image embedding, you must qualify the path the the imagesdir, as shown above.
                             -->
                             <attributes>
+                                <source-highlighter>coderay</source-highlighter>
                                 <imagesdir>./images</imagesdir>
                                 <toc>left</toc>
                                 <icons>font</icons>

--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -13,9 +13,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
-        <jruby.version>9.2.11.1</jruby.version>
+        <jruby.version>9.2.9.0</jruby.version>
         <revealjs.version>3.8.0</revealjs.version>
         <!-- Use 'master' as version and remove the 'v' prefixing the download url to use the current snapshot version  -->
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.4.2</version>
+                <version>1.6.0</version>
                 <executions>
                     <execution>
                         <id>install-revealjs</id>
@@ -131,7 +131,6 @@
                             </requires>
                             <outputDirectory>${project.slides.directory}</outputDirectory>
                             <backend>revealjs</backend>
-                            <sourceHighlighter>rouge</sourceHighlighter>
                             <attributes>
                                 <!--
                                     As we are downloading reveal.js in runtime, it sits in a nonstandard folder `reveal.js-${revealjs.version}`
@@ -145,6 +144,7 @@
                                 <!-- can use any pygments/rouge css here -->
                                 <rouge-css>class</rouge-css>
                                 <customcss>styles/monokai.css</customcss>
+                                <source-highlighter>rouge</source-highlighter>
                             </attributes>
                         </configuration>
                     </execution>

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.0.2</asciidoctorj.diagram.version>
         <jruby.version>9.2.11.1</jruby.version>

--- a/asciidoctor-epub-example/pom.xml
+++ b/asciidoctor-epub-example/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.epub.version>1.5.0-alpha.16</asciidoctorj.epub.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <!-- for a correct kf8 generation, you'll need at least jRuby >= 9.1.8.0 -->
@@ -65,7 +65,6 @@
                         </goals>
                         <configuration>
                             <backend>epub3</backend>
-                            <sourceHighlighter>coderay</sourceHighlighter>
                             <sourceDocumentName>spine.adoc</sourceDocumentName>
                         </configuration>
                     </execution>
@@ -90,9 +89,9 @@
                         </goals>
                         <configuration>
                             <backend>epub3</backend>
-                            <sourceHighlighter>coderay</sourceHighlighter>
                             <sourceDocumentName>spine.adoc</sourceDocumentName>
                             <attributes>
+                                <source-highlighter>coderay</source-highlighter>
                                 <ebook-format>kf8</ebook-format>
                             </attributes>
                         </configuration>

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
         <jruby.version>9.2.11.1</jruby.version>
@@ -241,8 +241,8 @@
                             <backend>pdf</backend>
                             <sourceDirectory>src/docs/asciidoc</sourceDirectory>
                             <sourceDocumentName>README-zh_CN.adoc</sourceDocumentName>
-                            <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
+                                <source-highlighter>coderay</source-highlighter>
                                 <allow-uri-read/>
                                 <icons>font</icons>
                                 <pagenums/>
@@ -268,8 +268,8 @@
                             <backend>pdf</backend>
                             <sourceDirectory>src/docs/asciidoc</sourceDirectory>
                             <sourceDocumentName>README-jp.adoc</sourceDocumentName>
-                            <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
+                                <source-highlighter>coderay</source-highlighter>
                                 <allow-uri-read/>
                                 <icons>font</icons>
                                 <pagenums/>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <jruby.version>9.2.11.1</jruby.version>
@@ -67,8 +67,8 @@
                                                      https://github.com/asciidoctor/asciidoctorj-pdf/issues/3
                                                      https://github.com/jneen/rouge/issues/661
                             -->
-                            <sourceHighlighter>coderay</sourceHighlighter>
                             <attributes>
+                                <source-highlighter>coderay</source-highlighter>
                                 <icons>font</icons>
                                 <pagenums/>
                                 <toc/>

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <jruby.version>9.2.11.1</jruby.version>
@@ -61,9 +61,9 @@
                         <configuration>
                             <backend>pdf</backend>
                             <outputDirectory>${project.build.directory}/generated-docs-default-theme</outputDirectory>
-                            <sourceHighlighter>coderay</sourceHighlighter>
                             <doctype>book</doctype>
                             <attributes>
+                                <source-highlighter>coderay</source-highlighter>
                                 <icons>font</icons>
                                 <pagenums/>
                                 <toc/>
@@ -81,12 +81,12 @@
                         <configuration>
                             <backend>pdf</backend>
                             <outputDirectory>${project.build.directory}/generated-docs-custom-theme</outputDirectory>
-                            <sourceHighlighter>coderay</sourceHighlighter>
                             <!-- Use `book` docType to enable title page generation -->
                             <doctype>book</doctype>
                             <attributes>
                                 <pdf-stylesdir>${project.basedir}/src/theme</pdf-stylesdir>
                                 <pdf-style>custom</pdf-style>
+                                <source-highlighter>coderay</source-highlighter>
                                 <icons>font</icons>
                                 <pagenums/>
                                 <toc/>

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <jruby.version>9.2.11.1</jruby.version>
     </properties>

--- a/docbook-pipeline-jdocbook-example/pom.xml
+++ b/docbook-pipeline-jdocbook-example/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <jruby.version>9.2.11.1</jruby.version>
     </properties>

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -10,7 +10,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <jruby.version>9.2.11.1</jruby.version>
     </properties>
@@ -64,7 +64,6 @@
                         </goals>
                         <configuration>
                             <backend>html5</backend>
-                            <sourceHighlighter>coderay</sourceHighlighter>
                             <!--
                             Scenarios for linking vs embedding assets:
 
@@ -115,6 +114,7 @@
                             IMPORTANT: When you enable image embedding, you must qualify the path the the imagesdir, as shown above.
                             -->
                             <attributes>
+                                <source-highlighter>coderay</source-highlighter>
                                 <icons>font</icons>
                                 <sectanchors>true</sectanchors>
                                 <!-- set the idprefix to blank -->

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asciidoctor.maven.plugin.version>2.0.0-RC.1</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.0.2</asciidoctorj.diagram.version>


### PR DESCRIPTION
All examples working with asciidoctor-maven-plugin v 2.0.0.

About reveal.js to make it work we are using jruby 9.2.9.0 untill the known issues in gem-maven-plugin is fixed.