### PR TITLE
bump asciidoctorj-epub3 to v1.5.0-alpha.18 + excludes resources from target dir

### DIFF
--- a/asciidoctor-epub-example/pom.xml
+++ b/asciidoctor-epub-example/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
-        <asciidoctorj.epub.version>1.5.0-alpha.16</asciidoctorj.epub.version>
+        <asciidoctorj.epub.version>1.5.0-alpha.18</asciidoctorj.epub.version>
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <!-- for a correct kf8 generation, you'll need at least jRuby >= 9.1.8.0 -->
         <jruby.version>9.2.11.1</jruby.version>
@@ -54,6 +54,14 @@
                     <attributes>
                         <sourcedir>${project.build.sourceDirectory}</sourcedir>
                     </attributes>
+                    <resources>
+                        <resource>
+                            <directory>.</directory>
+                            <excludes>
+                                <exclude>**/**</exclude>
+                            </excludes>
+                        </resource>
+                    </resources>
                 </configuration>
                 <executions>
                     <!-- shows how to create an epub file -->

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <asciidoctorj.version>2.3.0</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.0.2</asciidoctorj.diagram.version>
         <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
-        <asciidoctorj.epub.version>1.5.0-alpha.16</asciidoctorj.epub.version>
+        <asciidoctorj.epub.version>1.5.0-alpha.18</asciidoctorj.epub.version>
         <jruby.version>9.2.11.1</jruby.version>
     </properties>
 


### PR DESCRIPTION
This PR:
* Bump asciidoctoj-epub3 version to latest version 1.5.0-alpha.18
* Also add resources/exclusion configuration to avoid copying unnecessary resourtes to the output directory.