### PR TITLE
bumps asciidoctor-reveal.js to 4.0.1 and reveal.js to 3.9.2

### DIFF
--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -16,7 +16,7 @@
         <asciidoctor.maven.plugin.version>2.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.4.0</asciidoctorj.version>
         <jruby.version>9.2.9.0</jruby.version>
-        <revealjs.version>3.8.0</revealjs.version>
+        <revealjs.version>3.9.2</revealjs.version>
         <!-- Use 'master' as version and remove the 'v' prefixing the download url to use the current snapshot version  -->
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
     </properties>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>rubygems</groupId>
             <artifactId>asciidoctor-revealjs</artifactId>
-            <version>3.0.0</version>
+            <version>4.0.1</version>
             <type>gem</type>
             <!-- Avoid downloading gems included in AsciidoctorJ -->
             <exclusions>


### PR DESCRIPTION
Upgraded and tests latest asciidoctor-reveal.js version 4.0.1.
Also upgraded reveal.js to 3.9.2, which is the latests compatible. Due to breaking changes in 4.0.0, we cannot use it yet (https://github.com/asciidoctor/asciidoctor-reveal.js/issues/370).