### PR TITLE
Bump Asciidoctorj-pdf to v1.6.0

### DIFF
--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.1.0</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.4</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
         <asciidoctorj.version>2.5.1</asciidoctorj.version>
         <jruby.version>9.2.17.0</jruby.version>
     </properties>

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -17,7 +17,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.1.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.1</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.5.4</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
         <jruby.version>9.2.17.0</jruby.version>
         <pdf.cjk.version>0.1.3</pdf.cjk.version>
         <pdf.cjk.kaigen.version>0.1.1</pdf.cjk.kaigen.version>
@@ -242,6 +242,7 @@
                             <sourceDirectory>src/docs/asciidoc</sourceDirectory>
                             <sourceDocumentName>README-zh_CN.adoc</sourceDocumentName>
                             <attributes>
+                                <imagesdir>images</imagesdir>
                                 <source-highlighter>coderay</source-highlighter>
                                 <allow-uri-read/>
                                 <icons>font</icons>
@@ -269,6 +270,7 @@
                             <sourceDirectory>src/docs/asciidoc</sourceDirectory>
                             <sourceDocumentName>README-jp.adoc</sourceDocumentName>
                             <attributes>
+                                <imagesdir>images</imagesdir>
                                 <source-highlighter>coderay</source-highlighter>
                                 <allow-uri-read/>
                                 <icons>font</icons>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.1.0</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.4</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
         <asciidoctorj.version>2.5.1</asciidoctorj.version>
         <jruby.version>9.2.17.0</jruby.version>
     </properties>

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.1.0</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.5.4</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
         <asciidoctorj.version>2.5.1</asciidoctorj.version>
         <jruby.version>9.2.17.0</jruby.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
         <asciidoctorj.version>2.5.1</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.1.2</asciidoctorj.diagram.version>
-        <asciidoctorj.pdf.version>1.5.4</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>1.6.0</asciidoctorj.pdf.version>
         <asciidoctorj.epub.version>1.5.0-alpha.18</asciidoctorj.epub.version>
         <jruby.version>9.2.17.0</jruby.version>
     </properties>


### PR DESCRIPTION
* Updated and validated locally.
* Added missing `imagesdir` configuration to `asciidoctor-pdf-cjk-example`.