### PR TITLE
Extend asciidoctor-pdf default theme in asciidoctor-pdf-with-theme-example

### DIFF
--- a/asciidoctor-pdf-with-theme-example/README.adoc
+++ b/asciidoctor-pdf-with-theme-example/README.adoc
@@ -1,7 +1,7 @@
 = Asciidoctor Maven Plugin: AsciiDoc to PDF Book Example
 
 An example project that demonstrates how to convert AsciiDoc to PDF using Asciidoctor PDF with the Asciidoctor Maven plugin.
-This example produces a book and make use of a YAML style sheet (defined in `src/theme`).
+This example produces a book and make use of a custom https://github.com/asciidoctor/asciidoctor-pdf/blob/v1.6.x/docs/theming-guide.adoc[Asciidoctor PDF theme] (defined in `src/theme`).
 The same document is rendered twice:
 
 * Without the theme configuration, output is `target/generated-docs-default-theme/example-manual.pdf`

--- a/asciidoctor-pdf-with-theme-example/src/theme/custom-theme.yml
+++ b/asciidoctor-pdf-with-theme-example/src/theme/custom-theme.yml
@@ -1,20 +1,17 @@
+extends:
+  - default-with-fallback-font
 title-page:
   align: left
   logo:
     image: image:cover.png[align=center]
     top: 0%
 page:
-  layout: portrait
   margin: [0.75in, 1in, 0.75in, 1in]
-  size: A4
 base:
-  font-color: #333333
   line-height-length: 20
-  line-height: $base-line-height-length / $base-font-size
 heading:
   font-color: #FF8000
   font-size: 12
-  font-style: bold
   line-height: 1.2
 link:
   font-color: #009900


### PR DESCRIPTION
The correct approach to create a PDF theme is to extend from the default one with contains a good base to work upon instead creating one from scratch.

As approach, I added the `extends: default` to the theme file and remove properties with same value in https://github.com/asciidoctor/asciidoctor-pdf/blob/main/data/themes/default-theme.yml. Seeing the new PDF uses Noto fonts I'd say it works :+1: 