### PR TITLE
Bump Asciidoctorj-pdf to latest v2.0.6

### DIFF
--- a/asciidoc-maven-site-example/pom.xml
+++ b/asciidoc-maven-site-example/pom.xml
@@ -14,8 +14,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <jruby.version>9.3.4.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -13,9 +13,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.6.2</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <asciidoctorj.pdf.version>2.0.6</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <jruby.version>9.3.4.0</jruby.version>
     </properties>
 
     <build>
@@ -47,7 +47,7 @@
                 <configuration>
                     <!-- Attributes common to all output formats -->
                     <attributes>
-                        <endpoint-url>http://example.org</endpoint-url>
+                        <endpoint-url>https://example.org</endpoint-url>
                         <sourcedir>${project.build.sourceDirectory}</sourcedir>
                         <project-version>${project.version}</project-version>
                     </attributes>

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <jruby.version>9.3.4.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-to-html-multipage-example/pom.xml
+++ b/asciidoc-to-html-multipage-example/pom.xml
@@ -17,7 +17,7 @@
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.4</asciidoctorj.version>
         <asciidoctor-multipage.version>0.0.15</asciidoctor-multipage.version>
-        <jruby.version>9.2.9.0</jruby.version>
+        <jruby.version>9.3.4.0</jruby.version>
     </properties>
 
     <dependencies>

--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
+        <asciidoctorj.version>2.5.4</asciidoctorj.version>
         <jruby.version>9.2.9.0</jruby.version>
         <revealjs.version>3.9.2</revealjs.version>
         <!-- Use 'master' as version and remove the 'v' prefixing the download url to use the current snapshot version  -->

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -11,9 +11,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
-        <asciidoctorj.diagram.version>2.2.1</asciidoctorj.diagram.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.diagram.version>2.2.3</asciidoctorj.diagram.version>
+        <jruby.version>9.3.4.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoctor-epub-example/pom.xml
+++ b/asciidoctor-epub-example/pom.xml
@@ -16,9 +16,9 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.epub.version>1.5.1</asciidoctorj.epub.version>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
+        <asciidoctorj.version>2.5.4</asciidoctorj.version>
         <!-- for a correct kf8 generation, you'll need at least jRuby >= 9.1.8.0 -->
-        <jruby.version>9.2.20.1</jruby.version>
+        <jruby.version>9.3.4.0</jruby.version>
         <!-- provide full path to kindlegen application if you need the fallback solution -->
         <path.to.kindlegen>/absolute/path/to/kindlegen</path.to.kindlegen>
     </properties>

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -16,9 +16,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
-        <asciidoctorj.pdf.version>1.6.2</asciidoctorj.pdf.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.pdf.version>2.0.6</asciidoctorj.pdf.version>
+        <jruby.version>9.3.4.0</jruby.version>
         <pdf.cjk.version>0.1.3</pdf.cjk.version>
         <pdf.cjk.kaigen.version>0.1.1</pdf.cjk.kaigen.version>
         <pdf.cjk.kaigen.fonts.download.uri>https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic/releases/download/v0.1.0-fonts</pdf.cjk.kaigen.fonts.download.uri>

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -253,8 +253,8 @@
                                 <!-- Fixes line wraps formatting inserting zero-width spaces (ZWSP) before CJ characters -->
                                 <scripts>cjk</scripts>
                                 <!-- Set KaiGen Gothic Chinese theme -->
-                                <pdf-style>KaiGenGothicCN</pdf-style>
-                                <pdf-stylesdir>${pdf.cjk.kaigen.download.dir}/themes</pdf-stylesdir>
+                                <pdf-theme>KaiGenGothicCN</pdf-theme>
+                                <pdf-themesdir>${pdf.cjk.kaigen.download.dir}/themes</pdf-themesdir>
                                 <pdf-fontsdir>${pdf.cjk.kaigen.download.dir}/fonts</pdf-fontsdir>
                             </attributes>
                         </configuration>
@@ -281,8 +281,8 @@
                                 <!-- Fixes line wraps formatting inserting zero-width spaces (ZWSP) before CJ characters -->
                                 <scripts>cjk</scripts>
                                 <!-- Set KaiGen Gothic Japanese theme -->
-                                <pdf-style>KaiGenGothicJP</pdf-style>
-                                <pdf-stylesdir>${pdf.cjk.kaigen.download.dir}/themes</pdf-stylesdir>
+                                <pdf-theme>KaiGenGothicJP</pdf-theme>
+                                <pdf-themesdir>${pdf.cjk.kaigen.download.dir}/themes</pdf-themesdir>
                                 <pdf-fontsdir>${pdf.cjk.kaigen.download.dir}/fonts</pdf-fontsdir>
                             </attributes>
                         </configuration>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -13,9 +13,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.6.2</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <asciidoctorj.pdf.version>2.0.6</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <jruby.version>9.3.3.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -84,8 +84,8 @@
                             <!-- Use `book` docType to enable title page generation -->
                             <doctype>book</doctype>
                             <attributes>
-                                <pdf-stylesdir>${project.basedir}/src/theme</pdf-stylesdir>
-                                <pdf-style>custom</pdf-style>
+                                <pdf-theme>custom</pdf-theme>
+                                <pdf-themesdir>${project.basedir}/src/theme</pdf-themesdir>
                                 <source-highlighter>coderay</source-highlighter>
                                 <icons>font</icons>
                                 <pagenums/>

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -13,9 +13,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.pdf.version>1.6.2</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <asciidoctorj.pdf.version>2.0.6</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <jruby.version>9.3.4.0</jruby.version>
     </properties>
 
     <build>

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <jruby.version>9.3.4.0</jruby.version>
     </properties>
 
     <build>

--- a/docbook-pipeline-jdocbook-example/pom.xml
+++ b/docbook-pipeline-jdocbook-example/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <jruby.version>9.3.4.0</jruby.version>
     </properties>
 
     <repositories>

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.3</asciidoctorj.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <jruby.version>9.3.4.0</jruby.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
         <asciidoctorj.version>2.5.4</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.2.3</asciidoctorj.diagram.version>
-        <asciidoctorj.pdf.version>1.6.2</asciidoctorj.pdf.version>
+        <asciidoctorj.pdf.version>2.0.6</asciidoctorj.pdf.version>
         <asciidoctorj.epub.version>1.5.1</asciidoctorj.epub.version>
-        <jruby.version>9.2.20.1</jruby.version>
+        <jruby.version>9.3.4.0</jruby.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Also:
* Bump missing modules to Asciidoctorj v2.5.4
* Bump jRuby to 9.3.4.0. Except those that use unsupported coderay
code examples, these fail and need 9.3.3.0.
* Fix asciidoctor-pdf-cjk-example & asciidoctor-pdf-with-theme-example: renamed `pdf-style` attribute to `pdf-theme`