### PR TITLE
Bump AsciidoctorJ to v2.5.5

### DIFF
--- a/asciidoc-maven-site-example/pom.xml
+++ b/asciidoc-maven-site-example/pom.xml
@@ -14,7 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <jruby.version>9.3.4.0</jruby.version>
     </properties>
 

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>2.1.6</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <jruby.version>9.3.4.0</jruby.version>
     </properties>
 

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <jruby.version>9.3.4.0</jruby.version>
     </properties>
 

--- a/asciidoc-to-html-multipage-example/pom.xml
+++ b/asciidoc-to-html-multipage-example/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <asciidoctor-multipage.version>0.0.16</asciidoctor-multipage.version>
         <jruby.version>9.3.4.0</jruby.version>
     </properties>

--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <jruby.version>9.2.9.0</jruby.version>
         <revealjs.version>3.9.2</revealjs.version>
         <!-- Use 'master' as version and remove the 'v' prefixing the download url to use the current snapshot version  -->

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.2.3</asciidoctorj.diagram.version>
         <jruby.version>9.3.4.0</jruby.version>
     </properties>

--- a/asciidoctor-epub-example/pom.xml
+++ b/asciidoctor-epub-example/pom.xml
@@ -14,9 +14,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
+        <asciidoctor.maven.plugin.version>3.0.0-SNAPSHOT</asciidoctor.maven.plugin.version>
         <asciidoctorj.epub.version>1.5.1</asciidoctorj.epub.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <!-- for a correct kf8 generation, you'll need at least jRuby >= 9.1.8.0 -->
         <jruby.version>9.3.4.0</jruby.version>
         <!-- provide full path to kindlegen application if you need the fallback solution -->

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <asciidoctorj.pdf.version>2.1.6</asciidoctorj.pdf.version>
         <jruby.version>9.3.4.0</jruby.version>
         <pdf.cjk.version>0.1.3</pdf.cjk.version>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>2.1.6</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <jruby.version>9.3.4.0</jruby.version>
     </properties>
 

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>2.1.6</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <jruby.version>9.3.4.0</jruby.version>
     </properties>
 

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <jruby.version>9.3.4.0</jruby.version>
     </properties>
 

--- a/docbook-pipeline-jdocbook-example/pom.xml
+++ b/docbook-pipeline-jdocbook-example/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <jruby.version>9.3.4.0</jruby.version>
     </properties>
 

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -11,7 +11,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <jruby.version>9.3.4.0</jruby.version>
     </properties>
 

--- a/java-extension-example/asciidoctorj-twitter-extension/pom.xml
+++ b/java-extension-example/asciidoctorj-twitter-extension/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
-        <asciidoctorj.version>2.5.4</asciidoctorj.version>
+        <asciidoctorj.version>2.5.5</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.2.3</asciidoctorj.diagram.version>
         <asciidoctorj.pdf.version>2.1.6</asciidoctorj.pdf.version>
         <asciidoctorj.epub.version>1.5.1</asciidoctorj.epub.version>


### PR DESCRIPTION
Found issue with epub and Java17 https://github.com/asciidoctor/asciidoctor-maven-examples/issues/141 but all the rest work as known. See no reason to block the bump.