### PR TITLE
#120 Automate examples validation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,54 @@
+name: Build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        java:
+          - 8
+          - 11
+          - 17
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-mvn-cache-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-mvn-cache-
+      - name: Install Graphviz (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install graphviz
+      - name: Install Graphviz (Win)
+        if: matrix.os == 'windows-latest'
+        run: choco install graphviz
+      - name: Install Graphviz (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install graphviz
+      - name: Environment
+        run: mvn -version
+      - name: Clean all modules
+        run: mvn -B clean
+      - name: Build
+        run: mvn -B test -pl tests

--- a/README.adoc
+++ b/README.adoc
@@ -164,6 +164,7 @@ Even when this project does not contain much code, we encourage the following go
 * Follow simples code conventions to improve readability on the web
 ** Use 4 white spaces instead of tabs
 ** Avoid long lines in the Java code (they’re good in AsciiDoc files though)
+* Tests are named after each example name.
 
 To help fixing some style conventions a small script has been included. Currently, it only checks for tabs, which should be replaced by white spaces.
 To see what files contain some inconsistency, run this command from the parent project.

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <module>asciidoc-multiple-inputs-example</module>
         <module>docbook-pipeline-docbkx-example</module>
         <module>java-extension-example</module>
+        <module>tests</module>
     </modules>
 
     <build>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.asciidoctor.maven.examples</groupId>
+    <artifactId>tests</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <junit.version>5.9.0</junit.version>
+        <assertj.version>3.23.1</assertj.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.26</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.10.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M7</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>

--- a/tests/src/test/java/org/asciidoctor/maven/examples/AsciidocMavenSiteTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/AsciidocMavenSiteTest.java
@@ -1,0 +1,50 @@
+package org.asciidoctor.maven.examples;
+
+import org.asciidoctor.maven.examples.tests.MavenProject;
+import org.asciidoctor.maven.examples.tests.MavenTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MavenTest(projectPath = "../asciidoc-maven-site-example", goal = "site:site")
+class AsciidocMavenSiteTest {
+
+    private MavenProject mavenProject;
+
+    @Test
+    void shouldGenerateSitePages() {
+        File index = mavenProject.getTarget(sitePage("index.html"));
+        assertThat(index)
+                .isNotEmpty()
+                .content()
+                .contains("<h1>AsciiDoc Maven Site Example</h1>")
+                .contains("<li class=\"nav-header\">Asciidoctor Example</li>")
+                .contains("<a href=\"hello.html\" title=\"Hello\"><span class=\"none\"></span>Hello</a>")
+                .contains("<a href=\"article.html\" title=\"Article\"><span class=\"none\"></span>Article</a>");
+
+        File hello = mavenProject.getTarget(sitePage("hello.html"));
+        assertThat(hello)
+                .isNotEmpty()
+                .content()
+                .contains("<h1>Hello, AsciiDoc!</h1>")
+                .contains("<img src=\"images/tiger.png\" alt=\"Ghostscript Tiger\"/>")
+                .contains("<h2 id=\"attributes\">Attributes</h2>");
+
+        File article = mavenProject.getTarget(sitePage("article.html"));
+        assertThat(article)
+                .isNotEmpty()
+                .content()
+                .contains("<h1>AsciiDoc is Writing Zen</h1>")
+                .contains("<h3 id=\"unordered_list\">")
+                .contains("<h3 id=\"ordered_list\">")
+                .contains("<h3 id=\"table\">")
+                .contains("<h3 id=\"code_blocks\">")
+                .contains("<h2 id=\"attributes\"><a class=\"anchor\" href=\"#attributes\"></a>Attributes</h2>");
+    }
+
+    private String sitePage(String filename) {
+        return "site/" + filename;
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/AsciidocMultipleInputsTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/AsciidocMultipleInputsTest.java
@@ -1,0 +1,48 @@
+package org.asciidoctor.maven.examples;
+
+import org.asciidoctor.maven.examples.tests.MavenProject;
+import org.asciidoctor.maven.examples.tests.MavenTest;
+import org.asciidoctor.maven.examples.common.StringUtils;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MavenTest(projectPath = "../asciidoc-multiple-inputs-example")
+class AsciidocMultipleInputsTest {
+
+    private MavenProject mavenProject;
+
+    @Test
+    void shouldGenerateHtml() {
+        File html = mavenProject.getTarget(generatedDoc("example-technical-doc.html"));
+        assertThat(html)
+                .isNotEmpty()
+                .content()
+                .contains("<meta name=\"generator\" content=\"Asciidoctor")
+                .contains(StringUtils.lines("<ul class=\"sectlevel1\">",
+                        "<li><a href=\"#chapter-1\">Chapter 1</a></li>",
+                        "<li><a href=\"#chapter-2\">Chapter 2</a></li>",
+                        "</ul>"))
+                .contains("<span id=\"author\" class=\"author\">Doc Writer</span>")
+                .contains("<h2 id=\"chapter-1\"><a class=\"anchor\" href=\"#chapter-1\"></a>Chapter 1</h2>")
+                .contains("<h2 id=\"chapter-2\"><a class=\"anchor\" href=\"#chapter-2\"></a>Chapter 2</h2>");
+    }
+
+    @Test
+    void shouldGeneratePdf() {
+        File pdf = mavenProject.getTarget(generatedDoc("example-manual.pdf"));
+        assertThat(pdf)
+                .isNotEmpty()
+                .content()
+                .startsWith("%PDF-1.4")
+                .contains("/Title (Example Manual)")
+                .contains("/Author (Doc Writer)")
+                .contains("/Creator (Asciidoctor PDF");
+    }
+
+    private String generatedDoc(String filename) {
+        return "generated-docs/" + filename;
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/AsciidocToHtmlMultipageTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/AsciidocToHtmlMultipageTest.java
@@ -1,0 +1,87 @@
+package org.asciidoctor.maven.examples;
+
+import org.asciidoctor.maven.examples.tests.MavenProject;
+import org.asciidoctor.maven.examples.tests.MavenTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MavenTest(projectPath = "../asciidoc-to-html-multipage-example")
+class AsciidocToHtmlMultipageTest {
+
+    private MavenProject mavenProject;
+
+    @Test
+    void shouldGenerateMultipleHtmlPages() {
+        File index = mavenProject.getTarget(docs("index.html"));
+        assertThat(index)
+                .content()
+                .contains("<meta name=\"generator\" content=\"Asciidoctor")
+                // TOC
+                .contains("<a href=\"introduction.html\">1. Introduction</a>")
+                .contains("<a href=\"source-code.html\">2. Source Code</a>")
+                .contains("<a href=\"images.html\">3. Images</a>")
+                .contains("<a href=\"attributes.html\">4. Attributes</a>")
+                .contains("<a href=\"includes.html\">5. Includes</a>")
+                // Navigation footer
+                .doesNotContain("Previous:")
+                .contains("<div class=\"paragraph nav-footer\">")
+                .contains("<p>Next:")
+                .contains("<a href=\"introduction.html\">Introduction</a>");
+
+        File introduction = mavenProject.getTarget(docs("introduction.html"));
+        assertThat(introduction)
+                .content()
+                .doesNotContain("Previous:")
+                .contains("Up:")
+                .contains("<a href=\"index.html\">Example Manual</a>")
+                .contains("Next:")
+                .contains("<a href=\"source-code.html\">Source Code</a>");
+
+        File sourceCode = mavenProject.getTarget(docs("source-code.html"));
+        assertThat(sourceCode)
+                .content()
+                .contains("Previous:")
+                .contains("<a href=\"introduction.html\">Introduction</a>")
+                .contains("Up:")
+                .contains("<a href=\"index.html\">Example Manual</a>")
+                .contains("Next:")
+                .contains("<a href=\"images.html\">Images</a>");
+
+        File images = mavenProject.getTarget(docs("images.html"));
+        assertThat(images)
+                .content()
+                .contains("Previous:")
+                .contains("<a href=\"source-code.html\">Source Code</a>")
+                .contains("Up:")
+                .contains("<a href=\"index.html\">Example Manual</a>")
+                .contains("Next:")
+                .contains("<a href=\"attributes.html\">Attributes</a>");
+
+        File attributes = mavenProject.getTarget(docs("attributes.html"));
+        assertThat(attributes)
+                .content()
+                .contains("Previous:")
+                .contains("<a href=\"images.html\">Images</a>")
+                .contains("Up:")
+                .contains("<a href=\"index.html\">Example Manual</a>")
+                .contains("Next:")
+                .contains("<a href=\"includes.html\">Includes</a>");
+
+        File includes = mavenProject.getTarget(docs("includes.html"));
+        assertThat(includes)
+                .isNotEmpty()
+                .content()
+                .contains("Previous:")
+                .contains("<a href=\"attributes.html\">Attributes</a>")
+                .contains("Up:")
+                .contains("<a href=\"index.html\">Example Manual</a>")
+                .doesNotContain("Next:");
+    }
+
+    private String docs(String filename) {
+        return "docs/multipage/" + filename;
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/AsciidocToHtmlTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/AsciidocToHtmlTest.java
@@ -1,0 +1,40 @@
+package org.asciidoctor.maven.examples;
+
+
+
+import org.asciidoctor.maven.examples.tests.MavenProject;
+import org.asciidoctor.maven.examples.tests.MavenTest;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MavenTest(projectPath = "../asciidoc-to-html-example")
+class AsciidocToHtmlTest {
+
+    private static Logger logger = LoggerFactory.getLogger(AsciidocToHtmlTest.class);
+
+    private MavenProject mavenProject;
+
+    @Test
+    void shouldGenerateHtml() {
+        logger.info(()-> "logging from test");
+        logger.info(()-> "logging from test");
+        logger.info(()-> "logging from test");
+        logger.info(()-> "logging from test");
+        logger.info(()-> "logging from test");
+        logger.info(()-> "logging from test");
+
+        File generatedDoc = mavenProject.getTarget("generated-docs/example-manual.html");
+
+        assertThat(generatedDoc)
+                .isNotEmpty()
+                .content()
+                .contains("<meta name=\"generator\" content=\"Asciidoctor")
+                .contains("<pre class=\"rouge highlight\">")
+                .contains("<em>src/docs/asciidoc/subdir/c.adoc</em>");
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/AsciidocToRevealjsTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/AsciidocToRevealjsTest.java
@@ -1,0 +1,47 @@
+package org.asciidoctor.maven.examples;
+
+import org.asciidoctor.maven.examples.tests.MavenProject;
+import org.asciidoctor.maven.examples.tests.MavenTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MavenTest(projectPath = "../asciidoc-to-revealjs-example")
+class AsciidocToRevealjsTest {
+
+    private MavenProject mavenProject;
+
+    @Test
+    void shouldGenerateRevealJsSlides() {
+        File slides = mavenProject.getTarget(generatedSlides("slides.html"));
+
+        assertThat(slides)
+                .isNotEmpty()
+                .content()
+                .doesNotContain("<meta name=\"generator\" content=\"Asciidoctor")
+                .contains("<title>Example Manual</title>")
+                .contains("<h2>Introduction</h2>")
+                .contains("<h2>Speaker Notes</h2>")
+                .contains("<h2>Source Code</h2>")
+                .contains("<h2>Blank screen</h2>")
+                .contains("<h2>Overview</h2>")
+                .contains("<h2>Including documents from subdir</h2>")
+                .contains("<h2>Images as background</h2>")
+                .contains("<h2>Attributes</h2>");
+
+        File sunsetImage = mavenProject.getTarget(generatedSlides("images/sunset.jpg"));
+        assertThat(sunsetImage)
+                .isNotEmpty();
+
+        File revealJsDistribution = mavenProject.getTarget(generatedSlides("reveal.js-3.9.2"));
+        assertThat(revealJsDistribution)
+                .isDirectory()
+                .isDirectoryContaining(file -> file.getName().equals("package.json"));
+    }
+
+    private String generatedSlides(String filename) {
+        return "generated-slides/" + filename;
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorDiagramTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorDiagramTest.java
@@ -1,0 +1,35 @@
+package org.asciidoctor.maven.examples;
+
+import org.asciidoctor.maven.examples.tests.MavenProject;
+import org.asciidoctor.maven.examples.tests.MavenTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MavenTest(projectPath = "../asciidoctor-diagram-example")
+class AsciidoctorDiagramTest {
+
+    private MavenProject mavenProject;
+
+    @Test
+    void shouldGenerateHtmlWithDiagrams() {
+        File htmlExampleManual = mavenProject.getTarget(generatedDocs("example-manual.html"));
+        assertThat(htmlExampleManual)
+                .isNotEmpty()
+                .content()
+                .contains("<meta name=\"generator\" content=\"Asciidoctor");
+
+        File revealJsDistribution = mavenProject.getTarget(generatedDocs("images"));
+        assertThat(revealJsDistribution)
+                .isDirectory()
+                .isDirectoryContaining(file -> file.getName().equals("asciidoctor-diagram-process.png"))
+                .isDirectoryContaining(file -> file.getName().equals("auth-protocol.png"))
+                .isDirectoryContaining(file -> file.getName().equals("dot-example.svg"));
+    }
+
+    private String generatedDocs(String filename) {
+        return "generated-docs/" + filename;
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorEpubTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorEpubTest.java
@@ -1,0 +1,32 @@
+package org.asciidoctor.maven.examples;
+
+import org.asciidoctor.maven.examples.tests.MavenProject;
+import org.asciidoctor.maven.examples.tests.MavenTest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Disabled("issue-141")
+@MavenTest(projectPath = "../asciidoctor-epub-example")
+class AsciidoctorEpubTest {
+
+    private MavenProject mavenProject;
+
+    @Test
+    void shouldGenerateEpubFiles() {
+        File epub = mavenProject.getTarget(generatedDocs("spine.epub"));
+        assertThat(epub)
+                .isNotEmpty();
+
+        File epubKf8 = mavenProject.getTarget(generatedDocs("spine-kf8.epub"));
+        assertThat(epubKf8)
+                .isNotEmpty();
+    }
+
+    private String generatedDocs(String filename) {
+        return "generated-docs/" + filename;
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorPdfCJKTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorPdfCJKTest.java
@@ -1,0 +1,71 @@
+package org.asciidoctor.maven.examples;
+
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDResources;
+import org.apache.pdfbox.pdmodel.font.PDFont;
+import org.asciidoctor.maven.examples.tests.MavenProject;
+import org.asciidoctor.maven.examples.tests.MavenTest;
+import org.asciidoctor.maven.examples.common.CustomAsserter;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MavenTest(projectPath = "../asciidoctor-pdf-cjk-example")
+class AsciidoctorPdfCJKTest {
+
+    private MavenProject mavenProject;
+
+    @Test
+    void shouldGenerateCnPdf() throws IOException {
+        File readmeCN = mavenProject.getTarget(generatedDocs("README-zh_CN.pdf"));
+        assertIsPdfAndContainsFont(readmeCN, "KaiGenGothicCN");
+    }
+
+    @Test
+    void shouldGenerateJpPdf() throws IOException {
+        File readmeJP = mavenProject.getTarget(generatedDocs("README-jp.pdf"));
+        assertIsPdfAndContainsFont(readmeJP, "KaiGenGothicJP");
+    }
+
+    private void assertIsPdfAndContainsFont(File readmeJP, String fontName) throws IOException {
+        CustomAsserter.assertFile(readmeJP)
+                .isPdf()
+                .hasTitle("Asciidoctor");
+        assertThat(extractFonts(PDDocument.load(readmeJP)))
+                .contains(fontName);
+    }
+
+    private Set<String> extractFonts(PDDocument pdf) throws IOException {
+        final Set<PDFont> fonts = new HashSet<>();
+
+        final Set<String> fontNamesClean = new HashSet<>();
+        for (int i = 0; i < pdf.getNumberOfPages(); i++) {
+            PDPage page = pdf.getPage(i);
+            PDResources resources = page.getResources();
+            for (COSName fontName : resources.getFontNames()) {
+                // PDFBox prints (but not throws) exception on missing fonts
+                PDFont font = resources.getFont(fontName);
+                if (font != null) {
+                    // Some fonts appear duplicated with composed names
+                    fonts.add(font);
+                    if (font.getName().contains("+"))
+                        fontNamesClean.add(font.getName().split("\\+")[1]);
+                    else
+                        fontNamesClean.add(font.getName());
+                }
+            }
+        }
+        return fontNamesClean;
+    }
+
+    private String generatedDocs(String filename) {
+        return "generated-docs/" + filename;
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorPdfTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorPdfTest.java
@@ -1,0 +1,27 @@
+package org.asciidoctor.maven.examples;
+
+import org.asciidoctor.maven.examples.tests.MavenProject;
+import org.asciidoctor.maven.examples.tests.MavenTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.asciidoctor.maven.examples.common.CustomAsserter.assertFile;
+
+@MavenTest(projectPath = "../asciidoctor-pdf-example")
+class AsciidoctorPdfTest {
+
+    private MavenProject mavenProject;
+
+    @Test
+    void shouldGeneratePdf() {
+        File readmeJP = mavenProject.getTarget(generatedDocs("example-manual.pdf"));
+        assertFile(readmeJP)
+                .isPdf()
+                .hasTitle("Example Manual");
+    }
+
+    private String generatedDocs(String filename) {
+        return "generated-docs/" + filename;
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorPdfWithThemeTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorPdfWithThemeTest.java
@@ -1,0 +1,74 @@
+package org.asciidoctor.maven.examples;
+
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDResources;
+import org.apache.pdfbox.pdmodel.graphics.PDXObject;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImage;
+import org.asciidoctor.maven.examples.tests.MavenProject;
+import org.asciidoctor.maven.examples.tests.MavenTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.asciidoctor.maven.examples.common.CustomAsserter.assertFile;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MavenTest(projectPath = "../asciidoctor-pdf-with-theme-example")
+class AsciidoctorPdfWithThemeTest {
+
+    private static final String OUTPUT_PDF_FILE = "example-manual.pdf";
+
+    private MavenProject mavenProject;
+
+    @Test
+    void shouldGeneratePdfWithCustomTheme() throws IOException {
+        File pdfWithCustomTheme = mavenProject.getTarget(generatedDocsWithCustomTheme(OUTPUT_PDF_FILE));
+        assertFile(pdfWithCustomTheme)
+                .isPdf()
+                .hasTitle("Example Manual");
+        assertImagesInFirstPage(pdfWithCustomTheme, 1);
+    }
+
+    @Test
+    void shouldGeneratePdfWithDefaultTheme() throws IOException {
+        File pdfWithDefaultTheme = mavenProject.getTarget(generatedDocsWithDefaultTheme(OUTPUT_PDF_FILE));
+        assertFile(pdfWithDefaultTheme)
+                .isPdf()
+                .hasTitle("Example Manual");
+        assertImagesInFirstPage(pdfWithDefaultTheme, 0);
+    }
+
+    private void assertImagesInFirstPage(File pdfWithCustomTheme, int imagesCount) throws IOException {
+        PDPage page = PDDocument
+                .load(pdfWithCustomTheme)
+                .getPage(0);
+        assertThat(getImages(page)).hasSize(imagesCount);
+    }
+
+    private List<PDImage> getImages(PDPage page) throws IOException {
+        final List<PDImage> images = new ArrayList<>();
+
+        PDResources resources = page.getResources();
+        for (COSName cosName : resources.getXObjectNames()) {
+            PDXObject xObject = resources.getXObject(cosName);
+            if (xObject instanceof PDImage) {
+                images.add((PDImage) xObject);
+            }
+        }
+
+        return images;
+    }
+
+    private String generatedDocsWithDefaultTheme(String filename) {
+        return "generated-docs-default-theme/" + filename;
+    }
+
+    private String generatedDocsWithCustomTheme(String filename) {
+        return "generated-docs-custom-theme/" + filename;
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/DocbookPipelineDocbkxTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/DocbookPipelineDocbkxTest.java
@@ -1,0 +1,41 @@
+package org.asciidoctor.maven.examples;
+
+import org.asciidoctor.maven.examples.tests.MavenProject;
+import org.asciidoctor.maven.examples.tests.MavenTest;
+import org.asciidoctor.maven.examples.common.CustomAsserter;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.asciidoctor.maven.examples.common.StringUtils.lines;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MavenTest(projectPath = "../docbook-pipeline-docbkx-example")
+class DocbookPipelineDocbkxTest {
+
+    private MavenProject mavenProject;
+
+    @Test
+    void shouldGenerateDocbook() {
+        File docbookFile = mavenProject.getTarget(generatedDocs("example-manual.xml"));
+        assertThat(docbookFile)
+                .isNotEmpty()
+                .content()
+                .startsWith(lines(
+                        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+                        "<?asciidoc-toc?>",
+                        "<?asciidoc-numbered?>",
+                        "<book xmlns=\"http://docbook.org/ns/docbook\" xmlns:xl=\"http://www.w3.org/1999/xlink\" version=\"5.0\" xml:lang=\"en\">"));
+    }
+
+    @Test
+    void shouldGeneratePdf() {
+        File pdfFile = mavenProject.getTarget(generatedDocs("example-manual.pdf"));
+        CustomAsserter.assertFile(pdfFile)
+                .isPdf();
+    }
+
+    private String generatedDocs(String filename) {
+        return "generated-docs/" + filename;
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/JavaExtensionTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/JavaExtensionTest.java
@@ -1,0 +1,30 @@
+package org.asciidoctor.maven.examples;
+
+import org.asciidoctor.maven.examples.tests.MavenProject;
+import org.asciidoctor.maven.examples.tests.MavenTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@MavenTest(projectPath = JavaExtensionTest.PROJECT_PATH)
+class JavaExtensionTest {
+
+    public static final String PROJECT_PATH = "../java-extension-example";
+
+    private MavenProject mavenProject;
+
+    @Test
+    void shouldGeneratePdfWithCustomTheme() {
+        File outputDirectory = new File(
+                new File(PROJECT_PATH, "asciidoctor-with-extension-example"),
+                "target/generated-docs");
+
+        File htmlWithExtension = new File(outputDirectory, "example-manual.html");
+        assertThat(htmlWithExtension)
+                .isNotEmpty()
+                .content()
+                .contains("<a href=\"https://www.twitter.com/mrhaki\">@mrhaki</a>");
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/common/CustomAsserter.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/common/CustomAsserter.java
@@ -1,0 +1,31 @@
+package org.asciidoctor.maven.examples.common;
+
+import org.assertj.core.api.AbstractStringAssert;
+import org.assertj.core.api.Assertions;
+
+import java.io.File;
+
+public class CustomAsserter {
+
+    public static PdfAsserter assertFile(File pdfFile) {
+        return new PdfAsserter(pdfFile);
+    }
+
+    public static class PdfAsserter {
+
+        private final AbstractStringAssert<?> content;
+
+        public PdfAsserter(File file) {
+            this.content = Assertions.assertThat(file).content();
+        }
+
+        public PdfAsserter isPdf() {
+            content.startsWith("%PDF-1.4");
+            return this;
+        }
+
+        public void hasTitle(String title) {
+            content.contains(String.format("/Title (%s)", title));
+        }
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/common/StringUtils.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/common/StringUtils.java
@@ -1,0 +1,15 @@
+package org.asciidoctor.maven.examples.common;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class StringUtils {
+
+    /**
+     * Applies OS specific linebreaks.
+     */
+    public static String lines(String... lines) {
+        return Arrays.stream(lines)
+                .collect(Collectors.joining(System.lineSeparator()));
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/tests/JUnitMavenRunnerExtension.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/tests/JUnitMavenRunnerExtension.java
@@ -1,0 +1,61 @@
+package org.asciidoctor.maven.examples.tests;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+public class JUnitMavenRunnerExtension implements TestInstancePostProcessor {
+
+    @Override
+    public void postProcessTestInstance(Object testInstance, ExtensionContext extensionContext) throws Exception {
+        final Field mavenProjectField = findMavenProjectField(testInstance);
+
+        if (mavenProjectField != null) {
+            injectMavenProject(testInstance, mavenProjectField);
+        }
+    }
+
+    private Field findMavenProjectField(Object testInstance) {
+        for (Field field : testInstance.getClass().getDeclaredFields()) {
+            if (MavenProject.class.equals(field.getType())) return field;
+        }
+        return null;
+    }
+
+    private void injectMavenProject(Object testInstance, Field mavenProjectField) throws IllegalAccessException {
+        String pathname = extractProjectPath(testInstance);
+        final File projectPath = new File(pathname);
+
+        int run = new MavenProjectBuilder()
+                .path(projectPath)
+                .goal(extractAnnotation(testInstance).goal())
+                .run();
+
+        if (run == 0) {
+            final MavenProject target = new MavenProject(projectPath);
+            if (Modifier.isPrivate(mavenProjectField.getModifiers())) {
+                mavenProjectField.setAccessible(true);
+                mavenProjectField.set(testInstance, target);
+                mavenProjectField.setAccessible(false);
+            } else {
+                mavenProjectField.set(testInstance, target);
+            }
+        } else {
+            throw new RuntimeException("Could not run Maven project");
+        }
+    }
+
+    private String extractProjectPath(Object testInstance) {
+        return extractAnnotation(testInstance)
+                .projectPath();
+    }
+
+    private MavenTest extractAnnotation(Object testInstance) {
+        return testInstance
+                .getClass()
+                .getAnnotation(MavenTest.class);
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/tests/MavenLocator.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/tests/MavenLocator.java
@@ -1,0 +1,108 @@
+package org.asciidoctor.maven.examples.tests;
+
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+// Inspired on org.apache.maven.shared.invoker.MavenCommandLineBuilder
+// from maven-invoker-plugin
+public class MavenLocator {
+
+    private static Logger logger = LoggerFactory.getLogger(MavenLocator.class);
+
+    private static final Pattern WINDOWS_NAME_PATTERN = Pattern.compile("^[w|W]in.*$");
+    private static final String MVN_BIN = "/bin/mvn";
+    private static final String SDKMAN_DEFAULT_MAVEN_PATH = ".sdkman/candidates/maven/current/";
+
+    private File baseDirectory;
+    private File mavenHome;
+    private final File sdkmanDirectory = new File(System.getProperty("user.home"), SDKMAN_DEFAULT_MAVEN_PATH);
+
+    private File mavenExecutable;
+
+    private void setupMavenHome() {
+
+        String candidateJavaHome = System.getProperty("maven.home");
+        if (candidateJavaHome == null) {
+            candidateJavaHome = System.getenv("MAVEN_HOME");
+        }
+        if (candidateJavaHome != null) {
+            this.mavenHome = new File(candidateJavaHome);
+        }
+
+        if (this.mavenHome != null && !this.mavenHome.isDirectory()) {
+            File binDir = this.mavenHome.getParentFile();
+            if (binDir != null && "bin".equals(binDir.getName())) {
+                this.mavenHome = binDir.getParentFile();
+            }
+        }
+
+        if (this.mavenHome != null && !this.mavenHome.isDirectory()) {
+            throw new IllegalStateException("Maven home is set to: '" + this.mavenHome + "' which is not a directory");
+        } else {
+            logger.info(() -> "Using maven.home: '" + this.mavenHome + "'.");
+        }
+    }
+
+    private void setupMavenExecutable() {
+
+        if (this.mavenExecutable == null) {
+            this.mavenExecutable = this.detectMavenExecutablePerOs(this.mavenHome, MVN_BIN);
+        }
+        if (this.mavenExecutable == null) {
+            this.mavenExecutable = this.detectMavenExecutablePerOs(this.baseDirectory, MVN_BIN);
+        }
+        if (this.mavenExecutable == null) {
+            this.mavenExecutable = this.detectMavenExecutablePerOs(this.sdkmanDirectory, MVN_BIN);
+        }
+
+        if (this.mavenExecutable == null) {
+            logger.info(() -> "Could not locate maven executable, attempting PATH");
+            this.mavenExecutable = new File("mvn");
+        } else {
+            try {
+                this.mavenExecutable = this.mavenExecutable.getCanonicalFile();
+            } catch (IOException var4) {
+                logger.debug(() -> String.format("Failed to canonicalize maven executable: '%s'. Using as-is.", this.mavenExecutable));
+            }
+        }
+    }
+
+    private File detectMavenExecutablePerOs(File baseDirectory, String executable) {
+        File executableFile;
+        if (isWindows()) {
+            executableFile = new File(baseDirectory, executable + ".cmd");
+            if (executableFile.isFile()) {
+                return executableFile;
+            }
+
+            executableFile = new File(baseDirectory, executable + ".bat");
+            if (executableFile.isFile()) {
+                return executableFile;
+            }
+        }
+
+        executableFile = new File(baseDirectory, executable);
+        return executableFile.isFile() ? executableFile : null;
+    }
+
+    private boolean isWindows() {
+        return WINDOWS_NAME_PATTERN.matcher(System.getProperty("os.name")).matches();
+    }
+
+    public File findExecutable() {
+        if (mavenExecutable == null) {
+            setupMavenHome();
+            setupMavenExecutable();
+        }
+        return mavenExecutable;
+    }
+
+    public MavenLocator baseDirectory(String baseDirectory) {
+        this.baseDirectory = new File(baseDirectory);
+        return this;
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/tests/MavenProject.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/tests/MavenProject.java
@@ -1,0 +1,20 @@
+package org.asciidoctor.maven.examples.tests;
+
+import java.io.File;
+
+public class MavenProject {
+
+    private final File projectPath;
+
+    public MavenProject(File projectPath) {
+        this.projectPath = projectPath;
+    }
+
+    public File getTarget() {
+        return new File(projectPath, "target");
+    }
+
+    public File getTarget(String path) {
+        return new File(projectPath, String.format("target/%s", path));
+    }
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/tests/MavenProjectBuilder.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/tests/MavenProjectBuilder.java
@@ -1,0 +1,75 @@
+package org.asciidoctor.maven.examples.tests;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MavenProjectBuilder {
+
+    private File path;
+    /**
+     * Equivalent to '-X,--debug'
+     */
+    private boolean debug;
+
+    private String goal;
+    private File repository;
+
+    /**
+     * Equivalent to '-f,--file'
+     */
+    public MavenProjectBuilder path(File path) {
+        this.path = path;
+        return this;
+    }
+
+    public MavenProjectBuilder goal(String goal) {
+        this.goal = goal;
+        return this;
+    }
+
+    public MavenProjectBuilder repository(File repository) {
+        this.repository = repository;
+        return this;
+    }
+
+    public int run() {
+        if (path == null) {
+            throw new RuntimeException("path cannot be null");
+        }
+        if (repository != null && !repository.exists()) {
+            throw new RuntimeException("repository does not exists: " + repository);
+        }
+        return new ProcessRunner(path.getAbsoluteFile(), buildCommand())
+                .run();
+    }
+
+    private List<String> buildCommand() {
+        final List<String> parts = new ArrayList<>();
+        File executable = new MavenLocator()
+                .baseDirectory(path.getAbsolutePath())
+                .findExecutable();
+        parts.add(executable.isAbsolute() ? executable.getAbsolutePath() : executable.getName());
+        parts.add("-B");
+        parts.add("--file");
+        parts.add(path.getAbsolutePath());
+        if (debug) {
+            parts.add("--debug");
+        }
+        if (repository != null) {
+            parts.add("--define");
+            parts.add("maven.repo.local=" + repository.getAbsolutePath());
+        }
+        if (goal != null && goal.length() > 0) {
+            parts.add(goal);
+        }
+        return parts;
+    }
+
+    // TODO Find way to change build dir from terminal. Try using '-Dproject.build.directory' does not work
+//    public MavenProjectBuilder targetPath(File target) {
+//        this.target = target;
+//        return this;
+//    }
+
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/tests/MavenTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/tests/MavenTest.java
@@ -1,0 +1,18 @@
+package org.asciidoctor.maven.examples.tests;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(JUnitMavenRunnerExtension.class)
+public @interface MavenTest {
+
+    String projectPath();
+
+    String goal() default "";
+}

--- a/tests/src/test/java/org/asciidoctor/maven/examples/tests/ProcessRunner.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/tests/ProcessRunner.java
@@ -1,0 +1,32 @@
+package org.asciidoctor.maven.examples.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+public class ProcessRunner {
+
+    private final File workingDir;
+    private final List<String> command;
+
+    public ProcessRunner(File workingDir, List<String> command) {
+        this.workingDir = workingDir;
+        this.command = command;
+    }
+
+    public int run() {
+        final ProcessBuilder processBuilder = new ProcessBuilder()
+                .directory(workingDir)
+                .command(command)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .redirectOutput(ProcessBuilder.Redirect.INHERIT);
+
+        try {
+            return processBuilder
+                    .start()
+                    .waitFor();
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Opening PR as DRAFT in case anyone wants to add feedback

- [x] Added new `tests` project: this allows to keep examples separated, maintining the goal that examples can be inidividaully copy-pasted as reference without added elements.
- [x] Create Junit5 extension to run maven builds from junit test. This helps keeping things concise and declarative.
- [x] Added 1 test class for each example: each tests tries to validate more than just "output is created" (except for epub)
- [x] Test Git Hub action
- [x] Review TODOs

closes #120 