### PR TITLE
Enable dependabot for automatic version bumping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Most of the maintenance in the repo is bumping version.
With this PR and previous addition of tests, we aim to automate the process to ensure the examples are up-to-date soon and easily.

However, we'll need to keen an eye, not sure how dependabot will behave with the moduel structure we have.