### PR TITLE
Remove use of jruby-complete & bump Asciidoctorj v2.5.6

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -69,7 +69,7 @@ Asciidoctor Maven plugin relies on https://github.com/asciidoctor/asciidoctor[as
     <dependencies>
         <dependency>
             <groupId>org.jruby</groupId>
-            <artifactId>jruby-complete</artifactId>
+            <artifactId>jruby</artifactId>
             <version>${jruby.version}</version>
         </dependency>
     <dependencies>

--- a/asciidoc-maven-site-example/pom.xml
+++ b/asciidoc-maven-site-example/pom.xml
@@ -14,8 +14,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
+        <jruby.version>9.3.8.0</jruby.version>
     </properties>
 
     <build>
@@ -51,7 +51,7 @@
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
+                        <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -14,8 +14,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>2.3.0</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
+        <jruby.version>9.3.8.0</jruby.version>
     </properties>
 
     <build>
@@ -34,7 +34,7 @@
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
+                        <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
+        <jruby.version>9.3.8.0</jruby.version>
     </properties>
 
     <build>
@@ -28,7 +28,7 @@
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
+                        <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->

--- a/asciidoc-to-html-multipage-example/pom.xml
+++ b/asciidoc-to-html-multipage-example/pom.xml
@@ -15,9 +15,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
         <asciidoctor-multipage.version>0.0.16</asciidoctor-multipage.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <jruby.version>9.3.8.0</jruby.version>
     </properties>
 
     <dependencies>
@@ -73,7 +73,7 @@
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
+                        <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->

--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -14,8 +14,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
+        <jruby.version>9.3.8.0</jruby.version>
         <revealjs.version>3.9.2</revealjs.version>
         <!-- Use 'master' as version and remove the 'v' prefixing the download url to use the current snapshot version  -->
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
@@ -103,7 +103,7 @@
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
+                        <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -11,9 +11,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.2.3</asciidoctorj.diagram.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <jruby.version>9.3.8.0</jruby.version>
     </properties>
 
     <build>
@@ -27,7 +27,7 @@
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
+                        <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->

--- a/asciidoctor-epub-example/pom.xml
+++ b/asciidoctor-epub-example/pom.xml
@@ -16,9 +16,9 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.epub.version>1.5.1</asciidoctorj.epub.version>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
         <!-- for a correct kf8 generation, you'll need at least jRuby >= 9.1.8.0 -->
-        <jruby.version>9.3.4.0</jruby.version>
+        <jruby.version>9.3.8.0</jruby.version>
         <!-- provide full path to kindlegen application if you need the fallback solution -->
         <path.to.kindlegen>/absolute/path/to/kindlegen</path.to.kindlegen>
     </properties>
@@ -39,7 +39,7 @@
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
+                        <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -16,9 +16,9 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
         <asciidoctorj.pdf.version>2.3.0</asciidoctorj.pdf.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <jruby.version>9.3.8.0</jruby.version>
         <pdf.cjk.version>0.1.3</pdf.cjk.version>
         <pdf.cjk.kaigen.version>0.1.1</pdf.cjk.kaigen.version>
         <pdf.cjk.kaigen.fonts.download.uri>https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic/releases/download/v0.1.0-fonts</pdf.cjk.kaigen.fonts.download.uri>
@@ -220,7 +220,7 @@
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
+                        <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -14,8 +14,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>2.3.0</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
+        <jruby.version>9.3.8.0</jruby.version>
     </properties>
 
     <build>
@@ -34,7 +34,7 @@
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
+                        <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -14,8 +14,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>2.3.0</asciidoctorj.pdf.version>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
+        <jruby.version>9.3.8.0</jruby.version>
     </properties>
 
     <build>
@@ -34,7 +34,7 @@
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
+                        <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -13,8 +13,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
+        <jruby.version>9.3.8.0</jruby.version>
     </properties>
 
     <build>
@@ -28,7 +28,7 @@
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
+                        <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -11,8 +11,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
+        <jruby.version>9.3.8.0</jruby.version>
     </properties>
 
     <build>
@@ -32,7 +32,7 @@
                     <!-- Comment this section to use the default jruby artifact provided by the plugin -->
                     <dependency>
                         <groupId>org.jruby</groupId>
-                        <artifactId>jruby-complete</artifactId>
+                        <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->

--- a/java-extension-example/asciidoctorj-twitter-extension/pom.xml
+++ b/java-extension-example/asciidoctorj-twitter-extension/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
-        <asciidoctorj.version>2.5.5</asciidoctorj.version>
+        <asciidoctorj.version>2.5.6</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.2.3</asciidoctorj.diagram.version>
         <asciidoctorj.pdf.version>2.3.0</asciidoctorj.pdf.version>
         <asciidoctorj.epub.version>1.5.1</asciidoctorj.epub.version>
-        <jruby.version>9.3.4.0</jruby.version>
+        <jruby.version>9.3.8.0</jruby.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Original `jruby` 9.2.20.1 version as still present in the plugin classpath which went unnoticed untill breaking changes where introduced in the itnernal API.

Also:
* Bumps AsciidoctorJ to v 2.5.6
* Bumps jRuby to v9.3.8.0

closes #156