### PR TITLE
Subresource Integrity for 3rd-party CDN jQuery

### DIFF
--- a/asciidoc-multiple-inputs-example/src/docs/asciidoc/user-manual/docinfo.html
+++ b/asciidoc-multiple-inputs-example/src/docs/asciidoc/user-manual/docinfo.html
@@ -1,1 +1,1 @@
-<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.js" integrity="sha384-CQyOkvfvCvhwQOdH5W6oGDYPTE7Q+FaLVAqTfeM2O2wECkW/92wC2/QIuQFRLNtj" crossorigin="anonymous"></script>

--- a/asciidoc-to-html-example/src/docs/asciidoc/docinfo.html
+++ b/asciidoc-to-html-example/src/docs/asciidoc/docinfo.html
@@ -1,1 +1,1 @@
-<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.js" integrity="sha384-CQyOkvfvCvhwQOdH5W6oGDYPTE7Q+FaLVAqTfeM2O2wECkW/92wC2/QIuQFRLNtj" crossorigin="anonymous"></script>


### PR DESCRIPTION
There are lots of reason reason users or this site should trust a third-party CDN (https://httptoolkit.com/blog/public-cdn-risks/). However, if we plan to use them, the least we can do is make said scripts just a bit more trustworthy. How can we achieve this?

1. move to `https://` instead of protocol less so the script is always loaded from a secure domain
2. add subresource integrity check which will verify the content is the content we expect with a known hash of the script (https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)
3. enable CORS set to “anonymous” (no credentials shared)