### PR TITLE
Workaround for netty-codec-http security issues

### DIFF
--- a/asciidoc-maven-site-example/pom.xml
+++ b/asciidoc-maven-site-example/pom.xml
@@ -16,6 +16,7 @@
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <jruby.version>9.3.8.0</jruby.version>
+        <netty.version>4.1.89.Final</netty.version>
     </properties>
 
     <build>
@@ -53,6 +54,13 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
+                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
+                    <dependency>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                        <version>${netty.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -16,6 +16,7 @@
         <asciidoctorj.pdf.version>2.3.4</asciidoctorj.pdf.version>
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <jruby.version>9.3.8.0</jruby.version>
+        <netty.version>4.1.89.Final</netty.version>
     </properties>
 
     <build>
@@ -36,6 +37,13 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
+                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
+                    <dependency>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                        <version>${netty.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -15,6 +15,7 @@
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <jruby.version>9.3.8.0</jruby.version>
+        <netty.version>4.1.89.Final</netty.version>
     </properties>
 
     <build>
@@ -30,6 +31,13 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
+                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
+                    <dependency>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                        <version>${netty.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>

--- a/asciidoc-to-html-multipage-example/pom.xml
+++ b/asciidoc-to-html-multipage-example/pom.xml
@@ -18,6 +18,7 @@
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <asciidoctor-multipage.version>0.0.16</asciidoctor-multipage.version>
         <jruby.version>9.3.8.0</jruby.version>
+        <netty.version>4.1.89.Final</netty.version>
     </properties>
 
     <dependencies>
@@ -75,6 +76,13 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
+                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
+                    <dependency>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                        <version>${netty.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>

--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -16,6 +16,7 @@
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <jruby.version>9.3.8.0</jruby.version>
+        <netty.version>4.1.89.Final</netty.version>
         <revealjs.version>3.9.2</revealjs.version>
         <!-- Use 'master' as version and remove the 'v' prefixing the download url to use the current snapshot version  -->
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
@@ -105,6 +106,13 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
+                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
+                    <dependency>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                        <version>${netty.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -14,6 +14,7 @@
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.2.4</asciidoctorj.diagram.version>
         <jruby.version>9.3.8.0</jruby.version>
+        <netty.version>4.1.89.Final</netty.version>
     </properties>
 
     <build>
@@ -29,6 +30,13 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
+                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
+                    <dependency>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                        <version>${netty.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>

--- a/asciidoctor-epub-example/pom.xml
+++ b/asciidoctor-epub-example/pom.xml
@@ -19,6 +19,7 @@
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <!-- for a correct kf8 generation, you'll need at least jRuby >= 9.1.8.0 -->
         <jruby.version>9.3.8.0</jruby.version>
+        <netty.version>4.1.89.Final</netty.version>
         <!-- provide full path to kindlegen application if you need the fallback solution -->
         <path.to.kindlegen>/absolute/path/to/kindlegen</path.to.kindlegen>
     </properties>
@@ -41,6 +42,13 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
+                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
+                    <dependency>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                        <version>${netty.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -19,6 +19,7 @@
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <asciidoctorj.pdf.version>2.3.4</asciidoctorj.pdf.version>
         <jruby.version>9.3.8.0</jruby.version>
+        <netty.version>4.1.89.Final</netty.version>
         <pdf.cjk.version>0.1.3</pdf.cjk.version>
         <pdf.cjk.kaigen.version>0.1.1</pdf.cjk.kaigen.version>
         <pdf.cjk.kaigen.fonts.download.uri>https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic/releases/download/v0.1.0-fonts</pdf.cjk.kaigen.fonts.download.uri>
@@ -222,6 +223,13 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
+                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
+                    <dependency>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                        <version>${netty.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -16,6 +16,7 @@
         <asciidoctorj.pdf.version>2.3.4</asciidoctorj.pdf.version>
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <jruby.version>9.3.8.0</jruby.version>
+        <netty.version>4.1.89.Final</netty.version>
     </properties>
 
     <build>
@@ -36,6 +37,13 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
+                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
+                    <dependency>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                        <version>${netty.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -16,6 +16,7 @@
         <asciidoctorj.pdf.version>2.3.4</asciidoctorj.pdf.version>
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <jruby.version>9.3.8.0</jruby.version>
+        <netty.version>4.1.89.Final</netty.version>
     </properties>
 
     <build>
@@ -36,6 +37,13 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
+                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
+                    <dependency>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                        <version>${netty.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -15,6 +15,7 @@
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <jruby.version>9.3.8.0</jruby.version>
+        <netty.version>4.1.89.Final</netty.version>
     </properties>
 
     <build>
@@ -30,6 +31,13 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
+                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
+                    <dependency>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                        <version>${netty.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -13,6 +13,7 @@
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.7</asciidoctorj.version>
         <jruby.version>9.3.8.0</jruby.version>
+        <netty.version>4.1.89.Final</netty.version>
     </properties>
 
     <build>
@@ -34,6 +35,13 @@
                         <groupId>org.jruby</groupId>
                         <artifactId>jruby</artifactId>
                         <version>${jruby.version}</version>
+                    </dependency>
+                    <!-- Comment this section to use the default netty-codec-http artifact provided by the plugin -->
+                    <!-- Workaround for security issues (fix CVE-2022-41915, CVE-2022-24823) in asciidoctor-maven-plugin v2.2.2 -->
+                    <dependency>
+                        <groupId>io.netty</groupId>
+                        <artifactId>netty-codec-http</artifactId>
+                        <version>${netty.version}</version>
                     </dependency>
                     <!-- Comment this section to use the default AsciidoctorJ artifact provided by the plugin -->
                     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <asciidoctorj.pdf.version>2.3.0</asciidoctorj.pdf.version>
         <asciidoctorj.epub.version>1.5.1</asciidoctorj.epub.version>
         <jruby.version>9.3.8.0</jruby.version>
+        <netty.version>4.1.89.Final</netty.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Workaround for netty-codec-http security issues added.

fix CVE-2022-41915, CVE-2022-24823

See also:

- https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/612
- https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/615

This change could be commented out or reverted, when there is a Patch Release for the asciidoctor-maven-plugin v2.2.2 available, that contains the fixes there.
Until then, this workaround prevents using vulnerable versions of netty-codec-http.