### PR TITLE
Deviating parent versions fixed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,9 +15,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.2.2</asciidoctor.maven.plugin.version>
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>
-        <asciidoctorj.version>2.5.6</asciidoctorj.version>
-        <asciidoctorj.diagram.version>2.2.3</asciidoctorj.diagram.version>
-        <asciidoctorj.pdf.version>2.3.0</asciidoctorj.pdf.version>
+        <asciidoctorj.version>2.5.7</asciidoctorj.version>
+        <asciidoctorj.diagram.version>2.2.4</asciidoctorj.diagram.version>
+        <asciidoctorj.pdf.version>2.3.4</asciidoctorj.pdf.version>
         <asciidoctorj.epub.version>1.5.1</asciidoctorj.epub.version>
         <jruby.version>9.3.8.0</jruby.version>
     </properties>


### PR DESCRIPTION
In the parent POM some versions deviating from the ones used in examples - that might confuse users.

This PR aligns them to the latest versions used in the examples.