### PR TITLE
Exclude JRuby from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+    ignore:
+      - dependency-name: "org.jruby:jruby"


### PR DESCRIPTION
JRuby is managed manually based on AsciidoctorJ version. But dependabot still creates PR that we need to close.

This PR is basically to reduce unnecessary work.