### PR TITLE
Bump asciidoctorj-diagram to v2.2.9

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,9 @@ jobs:
     name: Build
     strategy:
       fail-fast: false
-      max-parallel: 4
+      max-parallel: 8
       matrix:
         java:
-          - 8
           - 11
           - 17
         os:

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.10</asciidoctorj.version>
-        <asciidoctorj.diagram.version>2.2.7</asciidoctorj.diagram.version>
+        <asciidoctorj.diagram.version>2.2.9</asciidoctorj.diagram.version>
         <jruby.version>9.4.2.0</jruby.version>
     </properties>
 


### PR DESCRIPTION
* Remove Java8 testing since asciidoctorj-diagram only supports Java11 since v2.2.8