### PR TITLE
Lock Maven version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
       - "dependencies"
     ignore:
       - dependency-name: "org.jruby:jruby"
+      - dependency-name: "com.googlecode.maven-download-plugin:download-maven-plugin"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,28 +14,33 @@ jobs:
       fail-fast: false
       max-parallel: 8
       matrix:
-        java:
-          - 11
-          - 17
         os:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        java:
+          - 11
+          - 17
+        maven:
+          - 3.9.3
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
-      - uses: actions/setup-java@v2
+      - uses: s4u/setup-maven-action@v1.8.0
         with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java }}
+            java-distribution: 'temurin'
+            java-version: ${{ matrix.java }}
+            maven-version: ${{ matrix.maven }}
       - name: Cache dependencies
         uses: actions/cache@v3
+        env:
+            java_version: ${{ matrix.java }}
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-mvn-cache-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-mvn-cache-
+          key: mvn-cache-${{ runner.os }}-${{ env.java_version }}
+          restore-keys: mvn-cache-${{ runner.os }}-${{ env.java_version }}
       - name: Install Graphviz (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt install graphviz
@@ -51,3 +56,12 @@ jobs:
         run: mvn -B clean
       - name: Build
         run: mvn -B test -pl tests
+      - name: Upload test output
+        uses: actions/upload-artifact@v3
+        env:
+            os_name: ${{ matrix.os }}
+            java_version: ${{ matrix.java }}
+        if: always()
+        with:
+            name: tests-output-${{ env.os_name }}-${{ env.java_version }}
+            path: tests/target/*

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -32,7 +32,7 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>1.7.1</version>
+                <version>1.6.8</version>
                 <executions>
                     <!-- Chinese theme & fonts -->
                     <execution>


### PR DESCRIPTION
This PR was motivated by multiple PR failing to run tests, not being reproducible locally, and not having information to troubleshoot.

* Use 's4u/setup-maven-action' to lock Maven version to latest
* Add the upload of test outputs (compilation, reports, etc.)