### PR TITLE
Bump org.apache.pdfbox:pdfbox from 2.0.29 to 3.0.0

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
-            <version>2.0.29</version>
+            <version>3.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorPdfCJKTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorPdfCJKTest.java
@@ -1,9 +1,11 @@
 package org.asciidoctor.maven.examples;
 
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.PDResources;
+import org.apache.pdfbox.pdmodel.fdf.FDFDocument;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.asciidoctor.maven.examples.tests.MavenProject;
 import org.asciidoctor.maven.examples.tests.MavenTest;
@@ -38,7 +40,7 @@ class AsciidoctorPdfCJKTest {
         CustomAsserter.assertFile(readmeJP)
                 .isPdf()
                 .hasTitle("Asciidoctor");
-        assertThat(extractFonts(PDDocument.load(readmeJP)))
+        assertThat(extractFonts(Loader.loadPDF(readmeJP)))
                 .contains(fontName);
     }
 

--- a/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorPdfWithThemeTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorPdfWithThemeTest.java
@@ -1,5 +1,6 @@
 package org.asciidoctor.maven.examples;
 
+import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.cos.COSName;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
@@ -44,8 +45,8 @@ class AsciidoctorPdfWithThemeTest {
     }
 
     private void assertImagesInFirstPage(File pdfWithCustomTheme, int imagesCount) throws IOException {
-        PDPage page = PDDocument
-                .load(pdfWithCustomTheme)
+        PDPage page = Loader
+                .loadPDF(pdfWithCustomTheme)
                 .getPage(0);
         assertThat(getImages(page)).hasSize(imagesCount);
     }


### PR DESCRIPTION
Includes fixes for the new pdfbox API.