### PR TITLE
Add Java 21 to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Build
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 16
       matrix:
         os:
           - ubuntu-latest
@@ -21,14 +21,15 @@ jobs:
         java:
           - 11
           - 17
+          - 21
         maven:
-          - 3.9.3
+          - 3.9.6
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 1
-      - uses: s4u/setup-maven-action@v1.8.0
+      - uses: s4u/setup-maven-action@v1.11.0
         with:
             java-distribution: 'temurin'
             java-version: ${{ matrix.java }}


### PR DESCRIPTION
* Bump GH actions
  * checkout & cache 3 to 4
  * s4u/setup-maven-action v1.8.0 to v1.11.0
* Bump maven 3.9.3 to 3.9.6