### PR TITLE
Bump JRuby 9.4.2.0 to 9.4.5.0

### DIFF
--- a/asciidoc-maven-site-example/pom.xml
+++ b/asciidoc-maven-site-example/pom.xml
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.11</asciidoctorj.version>
-        <jruby.version>9.4.2.0</jruby.version>
+        <jruby.version>9.4.5.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-multiple-inputs-example/pom.xml
+++ b/asciidoc-multiple-inputs-example/pom.xml
@@ -15,7 +15,7 @@
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>2.3.10</asciidoctorj.pdf.version>
         <asciidoctorj.version>2.5.11</asciidoctorj.version>
-        <jruby.version>9.4.2.0</jruby.version>
+        <jruby.version>9.4.5.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-to-html-example/pom.xml
+++ b/asciidoc-to-html-example/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.11</asciidoctorj.version>
-        <jruby.version>9.4.2.0</jruby.version>
+        <jruby.version>9.4.5.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoc-to-html-multipage-example/pom.xml
+++ b/asciidoc-to-html-multipage-example/pom.xml
@@ -17,7 +17,7 @@
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.11</asciidoctorj.version>
         <asciidoctor-multipage.version>0.0.16</asciidoctor-multipage.version>
-        <jruby.version>9.4.2.0</jruby.version>
+        <jruby.version>9.4.5.0</jruby.version>
     </properties>
 
     <dependencies>

--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.11</asciidoctorj.version>
-        <jruby.version>9.4.2.0</jruby.version>
+        <jruby.version>9.4.5.0</jruby.version>
         <revealjs.version>3.9.2</revealjs.version>
         <!-- Use 'master' as version and remove the 'v' prefixing the download url to use the current snapshot version  -->
         <asciidoctor-revealjs.version>master</asciidoctor-revealjs.version>

--- a/asciidoctor-diagram-example/pom.xml
+++ b/asciidoctor-diagram-example/pom.xml
@@ -13,7 +13,7 @@
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.11</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.2.13</asciidoctorj.diagram.version>
-        <jruby.version>9.4.2.0</jruby.version>
+        <jruby.version>9.4.5.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoctor-epub-example/pom.xml
+++ b/asciidoctor-epub-example/pom.xml
@@ -18,7 +18,7 @@
         <asciidoctorj.epub.version>1.5.1</asciidoctorj.epub.version>
         <asciidoctorj.version>2.5.11</asciidoctorj.version>
         <!-- for a correct kf8 generation, you'll need at least jRuby >= 9.1.8.0 -->
-        <jruby.version>9.4.2.0</jruby.version>
+        <jruby.version>9.4.5.0</jruby.version>
         <!-- provide full path to kindlegen application if you need the fallback solution -->
         <path.to.kindlegen>/absolute/path/to/kindlegen</path.to.kindlegen>
     </properties>

--- a/asciidoctor-pdf-cjk-example/pom.xml
+++ b/asciidoctor-pdf-cjk-example/pom.xml
@@ -18,7 +18,7 @@
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.11</asciidoctorj.version>
         <asciidoctorj.pdf.version>2.3.10</asciidoctorj.pdf.version>
-        <jruby.version>9.4.2.0</jruby.version>
+        <jruby.version>9.4.5.0</jruby.version>
         <pdf.cjk.version>0.1.3</pdf.cjk.version>
         <pdf.cjk.kaigen.version>0.1.1</pdf.cjk.kaigen.version>
         <pdf.cjk.kaigen.fonts.download.uri>https://github.com/chloerei/asciidoctor-pdf-cjk-kai_gen_gothic/releases/download/v0.1.0-fonts</pdf.cjk.kaigen.fonts.download.uri>

--- a/asciidoctor-pdf-example/pom.xml
+++ b/asciidoctor-pdf-example/pom.xml
@@ -15,7 +15,7 @@
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>2.3.10</asciidoctorj.pdf.version>
         <asciidoctorj.version>2.5.11</asciidoctorj.version>
-        <jruby.version>9.4.2.0</jruby.version>
+        <jruby.version>9.4.5.0</jruby.version>
     </properties>
 
     <build>

--- a/asciidoctor-pdf-with-theme-example/pom.xml
+++ b/asciidoctor-pdf-with-theme-example/pom.xml
@@ -15,7 +15,7 @@
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.pdf.version>2.3.10</asciidoctorj.pdf.version>
         <asciidoctorj.version>2.5.11</asciidoctorj.version>
-        <jruby.version>9.4.2.0</jruby.version>
+        <jruby.version>9.4.5.0</jruby.version>
     </properties>
 
     <build>

--- a/docbook-pipeline-docbkx-example/pom.xml
+++ b/docbook-pipeline-docbkx-example/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.11</asciidoctorj.version>
-        <jruby.version>9.4.2.0</jruby.version>
+        <jruby.version>9.4.5.0</jruby.version>
     </properties>
 
     <build>

--- a/java-extension-example/asciidoctor-with-extension-example/pom.xml
+++ b/java-extension-example/asciidoctor-with-extension-example/pom.xml
@@ -12,7 +12,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asciidoctor.maven.plugin.version>2.2.4</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.11</asciidoctorj.version>
-        <jruby.version>9.4.2.0</jruby.version>
+        <jruby.version>9.4.5.0</jruby.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Aligned with version used in AsciidoctorJ 2.5.11