### PR TITLE
Example for PlantUML diagrams without Graphviz dot installation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,15 +43,6 @@ jobs:
           path: ~/.m2/repository
           key: mvn-cache-${{ runner.os }}-${{ env.java_version }}
           restore-keys: mvn-cache-${{ runner.os }}-${{ env.java_version }}
-      - name: Install Graphviz (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt install graphviz
-      - name: Install Graphviz (Win)
-        if: matrix.os == 'windows-latest'
-        run: choco install graphviz
-      - name: Install Graphviz (macOS)
-        if: matrix.os == 'macos-latest'
-        run: brew install graphviz
       - name: Environment
         run: mvn -version
       - name: Clean all modules

--- a/asciidoctor-diagram-example/src/docs/asciidoc/example-manual.adoc
+++ b/asciidoctor-diagram-example/src/docs/asciidoc/example-manual.adoc
@@ -42,7 +42,7 @@ Alice -> Bob: Another authentication Request
 Alice <-- Bob: another authentication Response
 ....
 
-[graphviz, dot-example, svg]
+[plantuml, dot-example]
 ----
 digraph g {
     a -> b

--- a/asciidoctor-diagram-example/src/docs/asciidoc/example-manual.adoc
+++ b/asciidoctor-diagram-example/src/docs/asciidoc/example-manual.adoc
@@ -42,6 +42,42 @@ Alice -> Bob: Another authentication Request
 Alice <-- Bob: another authentication Response
 ....
 
+[plantuml,aspectj-maven-multi-module]
+....
+@startuml
+
+!pragma layout smetana
+
+skinparam component {
+  BackgroundColor<<Using Aspects>> #EEEEFF
+  BorderColor<<Using Aspects>> black
+}
+
+node poms {
+
+    component "rootParentPOM"
+    component "aspectParentPOM"
+
+    [rootParentPOM] <|.. [aspectParentPOM]
+}
+
+node aspect_definition_projects {
+
+    component "validation-api"
+    component "validation-aspect"
+
+    [rootParentPOM] <|... [validation-api]
+    [rootParentPOM] <|.. [validation-aspect]
+    [validation-api] *-- [validation-aspect]
+    [validation-aspect] *-- [aspectParentPOM]
+}
+
+component "mavenProjectWithAspects"<<Using Aspects>>
+[aspectParentPOM] <|.. [mavenProjectWithAspects]
+
+@enduml
+....
+
 [plantuml, dot-example]
 ----
 digraph g {

--- a/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorDiagramTest.java
+++ b/tests/src/test/java/org/asciidoctor/maven/examples/AsciidoctorDiagramTest.java
@@ -26,7 +26,8 @@ class AsciidoctorDiagramTest {
                 .isDirectory()
                 .isDirectoryContaining(file -> file.getName().equals("asciidoctor-diagram-process.png"))
                 .isDirectoryContaining(file -> file.getName().equals("auth-protocol.png"))
-                .isDirectoryContaining(file -> file.getName().equals("dot-example.svg"));
+                .isDirectoryContaining(file -> file.getName().equals("dot-example.png"))
+                .isDirectoryContaining(file -> file.getName().equals("aspectj-maven-multi-module.png"));
     }
 
     private String generatedDocs(String filename) {


### PR DESCRIPTION
Hello.

I do not expect you to merge this as-is, feel free to
  * adjust the examples to your needs,
  * also update the [Asciidoctor docs for the PlantUML plugin](https://docs.asciidoctor.org/diagram-extension/latest/diagram_types/plantuml/) to mention the [Smetana engine](https://plantuml.com/de/smetana02), see also the [former Smetana repository](https://github.com/plantuml/smetana?tab=readme-ov-file) (now merged into PlantUML proper).