### PR TITLE
Fix examples using gem-maven-plugin

### DIFF
--- a/asciidoc-to-html-multipage-example/pom.xml
+++ b/asciidoc-to-html-multipage-example/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <asciidoctor.maven.plugin.version>3.0.0</asciidoctor.maven.plugin.version>
         <asciidoctorj.version>2.5.12</asciidoctorj.version>
-        <asciidoctor-multipage.version>0.0.16</asciidoctor-multipage.version>
+        <asciidoctor-multipage.version>0.0.19</asciidoctor-multipage.version>
         <jruby.version>9.4.6.0</jruby.version>
     </properties>
 
@@ -39,16 +39,16 @@
         <defaultGoal>process-resources</defaultGoal>
         <extensions>
             <extension> <!-- this allows us to download gems -->
-                <groupId>org.torquebox.mojo</groupId>
+                <groupId>org.jruby.maven</groupId>
                 <artifactId>mavengem-wagon</artifactId>
-                <version>1.0.3</version>
+                <version>2.0.2</version>
             </extension>
         </extensions>
         <plugins>
             <plugin>
-                <groupId>de.saumya.mojo</groupId>
+                <groupId>org.jruby.maven</groupId>
                 <artifactId>gem-maven-plugin</artifactId>
-                <version>2.0.1</version>
+                <version>3.0.2</version>
                 <configuration>
                     <jrubyVersion>${jruby.version}</jrubyVersion>
                     <gemHome>${project.build.directory}/gems</gemHome>

--- a/asciidoc-to-revealjs-example/pom.xml
+++ b/asciidoc-to-revealjs-example/pom.xml
@@ -49,9 +49,9 @@
         <defaultGoal>process-resources</defaultGoal>
         <extensions>
             <extension> <!-- this allows us to download gems -->
-                <groupId>org.torquebox.mojo</groupId>
+                <groupId>org.jruby.maven</groupId>
                 <artifactId>mavengem-wagon</artifactId>
-                <version>1.0.3</version>
+                <version>2.0.2</version>
             </extension>
         </extensions>
         <plugins>
@@ -76,9 +76,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>de.saumya.mojo</groupId>
+                <groupId>org.jruby.maven</groupId>
                 <artifactId>gem-maven-plugin</artifactId>
-                <version>2.0.1</version>
+                <version>3.0.2</version>
                 <configuration>
                     <jrubyVersion>${jruby.version}</jrubyVersion>
                     <gemHome>${project.build.directory}/gems</gemHome>


### PR DESCRIPTION
Issues seen recently downloading gem are fixed with the most recent version of the plugin/wagon. Dependabot did not bump automatically because the new versions changed the org.

* Replace de.saumya.mojo:gem-maven-plugin by org.jruby.maven:gem-maven-plugin
* Replace org.torquebox.mojo:mavengem-wagon by org.jruby.maven:mavengem-wagon