### PR TITLE
Exclude hidden files in site examples

### DIFF
--- a/asciidoc-maven-site-converter-example/pom.xml
+++ b/asciidoc-maven-site-converter-example/pom.xml
@@ -32,6 +32,10 @@
                     <locales>en</locales>
                     <inputEncoding>UTF-8</inputEncoding>
                     <outputEncoding>UTF-8</outputEncoding>
+                    <!-- Ignore files prefixed with underscore -->
+                    <moduleExcludes>
+                        <asciidoc>**/_*.adoc</asciidoc>
+                    </moduleExcludes>
                     <asciidoc>
                         <!-- Optional site-wide AsciiDoc attributes -->
                         <attributes>

--- a/asciidoc-maven-site-parser-example/pom.xml
+++ b/asciidoc-maven-site-parser-example/pom.xml
@@ -32,6 +32,10 @@
                     <locales>en</locales>
                     <inputEncoding>UTF-8</inputEncoding>
                     <outputEncoding>UTF-8</outputEncoding>
+                    <!-- Ignore files prefixed with underscore -->
+                    <moduleExcludes>
+                        <asciidoc>**/_*.adoc</asciidoc>
+                    </moduleExcludes>
                     <asciidoc>
                         <!-- Optional site-wide AsciiDoc attributes -->
                         <attributes>


### PR DESCRIPTION
Site integration follows different conventions from the AsciidoctorMojo. Hence "hidden" files and folders is not a feature.
But, files can be ignored using the configuration in the PR.