### PR TITLE
Allow jRuby to update via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     labels:
       - "dependencies"
     ignore:
-      - dependency-name: "org.jruby:jruby"
       - dependency-name: "com.googlecode.maven-download-plugin:download-maven-plugin"
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Similarly to https://github.com/asciidoctor/asciidoctor-maven-plugin/pull/965.

The effort to bump it manually is not worth it, and automating to be on the latest will allow us to anticipate user issues.